### PR TITLE
modal unit tests

### DIFF
--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -101,7 +101,8 @@ var CMS = {
         reloadBrowser: function (url, timeout, ajax) {
             var that = this;
             // is there a parent window?
-            var parent = (window.parent) ? window.parent : window;
+            var win = this._getWindow();
+            var parent = (win.parent) ? win.parent : win;
 
             // if there is an ajax reload, prioritize
             if (ajax) {
@@ -566,7 +567,19 @@ var CMS = {
         */
         allowTouchScrolling: function allowTouchScrolling(element, namespace) {
             element.off('touchmove.cms.preventscroll.' + namespace);
+        },
+
+        /**
+         * Returns window object.
+         *
+         * @method _getWindow
+         * @private
+         * @returns {Window}
+         */
+        _getWindow: function () {
+            return window;
         }
+
     };
 
     // shorthand for jQuery(document).ready();

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -14,1093 +14,1090 @@ var CMS = window.CMS || {};
 (function ($) {
     'use strict';
 
-    // shorthand for jQuery(document).ready();
-    $(function () {
+    /**
+        * The modal is triggered via API calls from the backend either
+        * through the toolbar navigation or from plugins. The APIs allow to
+        * open content from a url (iframe) or inject html directly.
+        *
+        * @class Modal
+        * @namespace CMS
+        * @uses CMS.API.Helpers
+        */
+    CMS.Modal = new CMS.Class({
+
+        implement: [CMS.API.Helpers],
+
+        options: {
+            onClose: false,
+            minHeight: 400,
+            minWidth: 800,
+            modalDuration: 200,
+            newPlugin: false,
+            resizable: true,
+            maximizable: true,
+            minimizable: true
+        },
+
+        initialize: function initialize(options) {
+            this.options = $.extend(true, {}, this.options, options);
+
+            // elements
+            this._setupUI();
+            // event emitter
+            this._setupEventEmitter();
+
+            // states and events
+            this.click = 'click.cms.modal';
+            this.pointerDown = 'pointerdown.cms.modal contextmenu.cms.modal';
+            this.pointerUp = 'pointerup.cms.modal pointercancel.cms.modal';
+            this.pointerMove = 'pointermove.cms.modal';
+            this.doubleClick = 'dblclick.cms.modal';
+            this.touchEnd = 'touchend.cms.modal';
+            this.maximized = false;
+            this.minimized = false;
+            this.triggerMaximized = false;
+            this.saved = false;
+        },
+
         /**
-         * The modal is triggered via API calls from the backend either
-         * through the toolbar navigation or from plugins. The APIs allow to
-         * open content from a url (iframe) or inject html directly.
-         *
-         * @class Modal
-         * @namespace CMS
-         * @uses CMS.API.Helpers
-         */
-        CMS.Modal = new CMS.Class({
+            * Setup event pubsub mechanism for the instance.
+            *
+            * @private
+            * @method _setupEventEmitter
+            */
+        _setupEventEmitter: function _setupEventEmitter() {
+            var that = this;
+            var bus = $({});
 
-            implement: [CMS.API.Helpers],
-
-            options: {
-                onClose: false,
-                minHeight: 400,
-                minWidth: 800,
-                modalDuration: 200,
-                newPlugin: false,
-                resizable: true,
-                maximizable: true,
-                minimizable: true
-            },
-
-            initialize: function initialize(options) {
-                this.options = $.extend(true, {}, this.options, options);
-
-                // elements
-                this._setupUI();
-                // event emitter
-                this._setupEventEmitter();
-
-                // states and events
-                this.click = 'click.cms.modal';
-                this.pointerDown = 'pointerdown.cms.modal contextmenu.cms.modal';
-                this.pointerUp = 'pointerup.cms.modal pointercancel.cms.modal';
-                this.pointerMove = 'pointermove.cms.modal';
-                this.doubleClick = 'dblclick.cms.modal';
-                this.touchEnd = 'touchend.cms.modal';
-                this.maximized = false;
-                this.minimized = false;
-                this.triggerMaximized = false;
-                this.saved = false;
-            },
-
-            /**
-             * Setup event pubsub mechanism for the instance.
-             *
-             * @private
-             * @method _setupEventEmitter
-             */
-            _setupEventEmitter: function _setupEventEmitter() {
-                var that = this;
-                var bus = $({});
-
-                function proxy(name) {
-                    return function () {
-                        bus[name].apply(bus, arguments);
-                        return that;
-                    };
-                }
-
-                this.trigger = proxy('trigger');
-                this.one = proxy('one');
-                this.on = proxy('on');
-                this.off = proxy('off');
-            },
-
-            /**
-             * Stores all jQuery references within `this.ui`.
-             *
-             * @method _setupUI
-             * @private
-             */
-            _setupUI: function _setupUI() {
-                var modal = $('.cms-modal');
-                this.ui = {
-                    modal: modal,
-                    body: $('html'),
-                    window: $(window),
-                    toolbarLeftPart: $('.cms-toolbar-left'),
-                    minimizeButton: modal.find('.cms-modal-minimize'),
-                    maximizeButton: modal.find('.cms-modal-maximize'),
-                    title: modal.find('.cms-modal-title'),
-                    titlePrefix: modal.find('.cms-modal-title-prefix'),
-                    titleSuffix: modal.find('.cms-modal-title-suffix'),
-                    resize: modal.find('.cms-modal-resize'),
-                    breadcrumb: modal.find('.cms-modal-breadcrumb'),
-                    closeAndCancel: modal.find('.cms-modal-close, .cms-modal-cancel'),
-                    modalButtons: modal.find('.cms-modal-buttons'),
-                    modalBody: modal.find('.cms-modal-body'),
-                    frame: modal.find('.cms-modal-frame'),
-                    shim: modal.find('.cms-modal-shim')
+            function proxy(name) {
+                return function () {
+                    bus[name].apply(bus, arguments);
+                    return that;
                 };
-            },
+            }
 
-            /**
-             * Sets up all the event handlers, such as maximize/minimize and resizing.
-             *
-             * @method _events
-             * @private
-             */
-            _events: function _events() {
-                var that = this;
+            this.trigger = proxy('trigger');
+            this.one = proxy('one');
+            this.on = proxy('on');
+            this.off = proxy('off');
+        },
 
-                // modal behaviours
-                this.ui.minimizeButton.
-                    off(this.click + ' ' + this.touchEnd)
-                    .on(this.click + ' ' + this.touchEnd, function (e) {
-                    e.preventDefault();
-                    that.minimize();
+        /**
+            * Stores all jQuery references within `this.ui`.
+            *
+            * @method _setupUI
+            * @private
+            */
+        _setupUI: function _setupUI() {
+            var modal = $('.cms-modal');
+            this.ui = {
+                modal: modal,
+                body: $('html'),
+                window: $(window),
+                toolbarLeftPart: $('.cms-toolbar-left'),
+                minimizeButton: modal.find('.cms-modal-minimize'),
+                maximizeButton: modal.find('.cms-modal-maximize'),
+                title: modal.find('.cms-modal-title'),
+                titlePrefix: modal.find('.cms-modal-title-prefix'),
+                titleSuffix: modal.find('.cms-modal-title-suffix'),
+                resize: modal.find('.cms-modal-resize'),
+                breadcrumb: modal.find('.cms-modal-breadcrumb'),
+                closeAndCancel: modal.find('.cms-modal-close, .cms-modal-cancel'),
+                modalButtons: modal.find('.cms-modal-buttons'),
+                modalBody: modal.find('.cms-modal-body'),
+                frame: modal.find('.cms-modal-frame'),
+                shim: modal.find('.cms-modal-shim')
+            };
+        },
+
+        /**
+            * Sets up all the event handlers, such as maximize/minimize and resizing.
+            *
+            * @method _events
+            * @private
+            */
+        _events: function _events() {
+            var that = this;
+
+            // modal behaviours
+            this.ui.minimizeButton.
+                off(this.click + ' ' + this.touchEnd)
+                .on(this.click + ' ' + this.touchEnd, function (e) {
+                e.preventDefault();
+                that.minimize();
+            });
+            this.ui.maximizeButton
+                .off(this.click + ' ' + this.touchEnd)
+                .on(this.click + ' ' + this.touchEnd, function (e) {
+                e.preventDefault();
+                that.maximize();
+            });
+
+            this.ui.title.off(this.pointerDown).on(this.pointerDown, function (e) {
+                e.preventDefault();
+                that._startMove(e);
+            });
+            this.ui.title.off(this.doubleClick).on(this.doubleClick, function () {
+                that.maximize();
+            });
+
+            this.ui.resize.off(this.pointerDown).on(this.pointerDown, function (e) {
+                e.preventDefault();
+                that._startResize(e);
+            });
+
+            this.ui.closeAndCancel
+                .off(this.click + ' ' + this.touchEnd)
+                .on(this.click + ' ' + this.touchEnd, function (e) {
+                that.options.onClose = null;
+                e.preventDefault();
+                that.close();
+            });
+
+            // elements within the window
+            this.ui.breadcrumb.off(this.click, 'a').on(this.click, 'a', function (e) {
+                e.preventDefault();
+                that._changeIframe($(this));
+            });
+        },
+
+        /**
+            * Opens the modal either in an iframe or renders markup.
+            *
+            * @method open
+            * @chainable
+            * @param {Object} opts either `opts.url` or `opts.html` are required
+            * @param {Object[]} [opts.breadcrumbs] collection of breadcrumb items
+            * @param {String|HTMLNode|jQuery} [opts.html] html markup to render
+            * @param {String} [opts.title] modal window main title (bold)
+            * @param {String} [opts.subtitle] modal window secondary title (normal)
+            * @param {String} [opts.url] url to render iframe, takes precedence over `opts.html`
+            * @param {Number} [opts.width] sets the width of the modal
+            * @param {Number} [opts.height] sets the height of the modal
+            */
+        open: function open(opts) {
+            // setup internals
+            if (!(opts && opts.url || opts && opts.html)) {
+                throw new Error('The arguments passed to "open" were invalid.');
+            }
+
+            // handle remove option when plugin is new
+            // cancel open process when switching context
+            if (CMS._newPlugin && !this._deletePlugin()) {
+                return false;
+            }
+
+            // We have to rebind events every time we open a modal
+            // because the event handlers contain references to the instance
+            // and since we reuse the same markup we need to update
+            // that instance reference every time.
+            this._events();
+
+            this.trigger('cms.modal.load');
+            // trigger the event also on the dom element,
+            // because if we load another modal while one is already open
+            // the older instance won't receive any updates
+            this.ui.modal.trigger('cms.modal.load');
+
+            // common elements state
+            this.ui.resize.toggle(this.options.resizable);
+            this.ui.minimizeButton.toggle(this.options.minimizable);
+            this.ui.maximizeButton.toggle(this.options.maximizable);
+
+            var position = this._calculateNewPosition(opts);
+
+            this.ui.maximizeButton.removeClass('cms-modal-maximize-active');
+            this.maximized = false;
+
+            // new plugin will freeze the creation process
+            if (this.options.newPlugin) {
+                CMS._newPlugin = this.options.newPlugin;
+            }
+
+            // because a new instance is called, we have to ensure minimized state is removed #3620
+            if (this.ui.body.hasClass('cms-modal-minimized')) {
+                this.minimized = true;
+                this.minimize();
+            }
+
+            // clear elements
+            this.ui.modalButtons.empty();
+            this.ui.breadcrumb.empty();
+
+            // remove class from modal when no breadcrumbs is rendered
+            this.ui.modal.removeClass('cms-modal-has-breadcrumb');
+
+            // hide tooltip
+            CMS.API.Tooltip.hide();
+
+            // redirect to iframe rendering if url is provided
+            if (opts.url) {
+                this._loadIframe({
+                    url: opts.url,
+                    title: opts.title,
+                    breadcrumbs: opts.breadcrumbs
                 });
-                this.ui.maximizeButton
-                    .off(this.click + ' ' + this.touchEnd)
-                    .on(this.click + ' ' + this.touchEnd, function (e) {
-                    e.preventDefault();
-                    that.maximize();
+            } else {
+                // if url is not provided we go for html
+                this._loadMarkup({
+                    html: opts.html,
+                    title: opts.title,
+                    subtitle: opts.subtitle
                 });
+            }
 
-                this.ui.title.off(this.pointerDown).on(this.pointerDown, function (e) {
-                    e.preventDefault();
-                    that._startMove(e);
-                });
-                this.ui.title.off(this.doubleClick).on(this.doubleClick, function () {
-                    that.maximize();
-                });
+            this.trigger('cms.modal.loaded');
 
-                this.ui.resize.off(this.pointerDown).on(this.pointerDown, function (e) {
-                    e.preventDefault();
-                    that._startResize(e);
-                });
+            // display modal
+            this._show($.extend({
+                duration: this.options.modalDuration
+            }, position));
 
-                this.ui.closeAndCancel
-                    .off(this.click + ' ' + this.touchEnd)
-                    .on(this.click + ' ' + this.touchEnd, function (e) {
-                    that.options.onClose = null;
-                    e.preventDefault();
-                    that.close();
-                });
+            return this;
+        },
 
-                // elements within the window
-                this.ui.breadcrumb.off(this.click, 'a').on(this.click, 'a', function (e) {
-                    e.preventDefault();
-                    that._changeIframe($(this));
-                });
-            },
+        /**
+            * Calculates coordinates and dimensions for modal placement
+            *
+            * @method _calculateNewPosition
+            * @private
+            * @param {Object} [opts]
+            * @param {Number} [opts.width] desired width of the modal
+            * @param {Number} [opts.height] desired height of the modal
+            */
+        _calculateNewPosition: function (opts) {
+            // lets set the modal width and height to the size of the browser
+            var widthOffset = 300; // adds margin left and right
+            var heightOffset = 300; // adds margin top and bottom;
+            var screenWidth = this.ui.window.width();
+            var screenHeight = this.ui.window.height();
+            var modalWidth = opts.width || this.options.minWidth;
+            var modalHeight = opts.height || this.options.minHeight;
+            // screen width and height calculation, WC = width
+            var screenWidthCalc = screenWidth >= (modalWidth + widthOffset);
+            var screenHeightCalc = screenHeight >= (modalHeight + heightOffset);
 
-            /**
-             * Opens the modal either in an iframe or renders markup.
-             *
-             * @method open
-             * @chainable
-             * @param {Object} opts either `opts.url` or `opts.html` are required
-             * @param {Object[]} [opts.breadcrumbs] collection of breadcrumb items
-             * @param {String|HTMLNode|jQuery} [opts.html] html markup to render
-             * @param {String} [opts.title] modal window main title (bold)
-             * @param {String} [opts.subtitle] modal window secondary title (normal)
-             * @param {String} [opts.url] url to render iframe, takes precedence over `opts.html`
-             * @param {Number} [opts.width] sets the width of the modal
-             * @param {Number} [opts.height] sets the height of the modal
-             */
-            open: function open(opts) {
-                // setup internals
-                if (!(opts && opts.url || opts && opts.html)) {
-                    throw new Error('The arguments passed to "open" were invalid.');
-                }
+            var width = screenWidthCalc && !opts.width ? screenWidth - widthOffset : modalWidth;
+            var height = screenHeightCalc && !opts.height ? screenHeight - heightOffset : modalHeight;
 
-                // handle remove option when plugin is new
-                // cancel open process when switching context
-                if (CMS._newPlugin && !this._deletePlugin()) {
-                    return false;
-                }
+            var currentLeft = this.ui.modal.css('left');
+            var currentTop = this.ui.modal.css('top');
+            var newLeft;
+            var newTop;
 
-                // We have to rebind events every time we open a modal
-                // because the event handlers contain references to the instance
-                // and since we reuse the same markup we need to update
-                // that instance reference every time.
-                this._events();
+            // jquery made me do it
+            if (currentLeft === '50%') {
+                currentLeft = screenWidth / 2;
+            }
+            if (currentTop === '50%') {
+                currentTop = screenHeight / 2;
+            }
 
-                this.trigger('cms.modal.load');
-                // trigger the event also on the dom element,
-                // because if we load another modal while one is already open
-                // the older instance won't receive any updates
-                this.ui.modal.trigger('cms.modal.load');
+            currentTop = parseInt(currentTop);
+            currentLeft = parseInt(currentLeft);
 
-                // common elements state
-                this.ui.resize.toggle(this.options.resizable);
-                this.ui.minimizeButton.toggle(this.options.minimizable);
-                this.ui.maximizeButton.toggle(this.options.maximizable);
+            // if new width/height go out of the screen - reset position to center of screen
+            if ((width / 2 + currentLeft > screenWidth) || (height / 2 + currentTop > screenHeight) ||
+                (currentLeft - width / 2 < 0) || (currentTop - height / 2 < 0)) {
+                newLeft = screenWidth / 2;
+                newTop = screenHeight / 2;
+            }
 
-                var position = this._calculateNewPosition(opts);
+            // in case, the modal is larger than the window, we trigger fullscreen mode
+            if (width >= screenWidth || height >= screenHeight) {
+                this.triggerMaximized = true;
+            }
 
-                this.ui.maximizeButton.removeClass('cms-modal-maximize-active');
-                this.maximized = false;
+            return {
+                width: width,
+                height: height,
+                top: newTop,
+                left: newLeft
+            };
+        },
 
-                // new plugin will freeze the creation process
-                if (this.options.newPlugin) {
-                    CMS._newPlugin = this.options.newPlugin;
-                }
-
-                // because a new instance is called, we have to ensure minimized state is removed #3620
-                if (this.ui.body.hasClass('cms-modal-minimized')) {
-                    this.minimized = true;
-                    this.minimize();
-                }
-
-                // clear elements
-                this.ui.modalButtons.empty();
-                this.ui.breadcrumb.empty();
-
-                // remove class from modal when no breadcrumbs is rendered
-                this.ui.modal.removeClass('cms-modal-has-breadcrumb');
-
-                // hide tooltip
-                CMS.API.Tooltip.hide();
-
-                // redirect to iframe rendering if url is provided
-                if (opts.url) {
-                    this._loadIframe({
-                        url: opts.url,
-                        title: opts.title,
-                        breadcrumbs: opts.breadcrumbs
-                    });
-                } else {
-                    // if url is not provided we go for html
-                    this._loadMarkup({
-                        html: opts.html,
-                        title: opts.title,
-                        subtitle: opts.subtitle
-                    });
-                }
-
-                this.trigger('cms.modal.loaded');
-
-                // display modal
-                this._show($.extend({
-                    duration: this.options.modalDuration
-                }, position));
-
-                return this;
-            },
-
-            /**
-             * Calculates coordinates and dimensions for modal placement
-             *
-             * @method _calculateNewPosition
-             * @private
-             * @param {Object} [opts]
-             * @param {Number} [opts.width] desired width of the modal
-             * @param {Number} [opts.height] desired height of the modal
-             */
-            _calculateNewPosition: function (opts) {
-                // lets set the modal width and height to the size of the browser
-                var widthOffset = 300; // adds margin left and right
-                var heightOffset = 300; // adds margin top and bottom;
-                var screenWidth = this.ui.window.width();
-                var screenHeight = this.ui.window.height();
-                var modalWidth = opts.width || this.options.minWidth;
-                var modalHeight = opts.height || this.options.minHeight;
-                // screen width and height calculation, WC = width
-                var screenWidthCalc = screenWidth >= (modalWidth + widthOffset);
-                var screenHeightCalc = screenHeight >= (modalHeight + heightOffset);
-
-                var width = screenWidthCalc && !opts.width ? screenWidth - widthOffset : modalWidth;
-                var height = screenHeightCalc && !opts.height ? screenHeight - heightOffset : modalHeight;
-
-                var currentLeft = this.ui.modal.css('left');
-                var currentTop = this.ui.modal.css('top');
-                var newLeft;
-                var newTop;
-
-                // jquery made me do it
-                if (currentLeft === '50%') {
-                    currentLeft = screenWidth / 2;
-                }
-                if (currentTop === '50%') {
-                    currentTop = screenHeight / 2;
-                }
-
-                currentTop = parseInt(currentTop);
-                currentLeft = parseInt(currentLeft);
-
-                // if new width/height go out of the screen - reset position to center of screen
-                if ((width / 2 + currentLeft > screenWidth) || (height / 2 + currentTop > screenHeight) ||
-                    (currentLeft - width / 2 < 0) || (currentTop - height / 2 < 0)) {
-                    newLeft = screenWidth / 2;
-                    newTop = screenHeight / 2;
-                }
-
-                // in case, the modal is larger than the window, we trigger fullscreen mode
-                if (width >= screenWidth || height >= screenHeight) {
-                    this.triggerMaximized = true;
-                }
-
-                return {
-                    width: width,
-                    height: height,
-                    top: newTop,
-                    left: newLeft
-                };
-            },
-
-            /**
-             * Animation helper for opening the sideframe.
-             *
-             * @method _show
-             * @private
-             * @param {Object} opts
-             * @param {Number} opts.width width of the modal
-             * @param {Number} opts.height height of the modal
-             * @param {Number} opts.left left in px of the center of the modal
-             * @param {Number} opts.top top in px of the center of the modal
-             * @param {Number} opts.duration speed of opening, ms (not really used yet)
-             */
-            _show: function _show(opts) {
-                // we need to position the modal in the center
-                var that = this;
-                var width = opts.width;
-                var height = opts.height;
-                // TODO make use of transitionDuration, currently capped at 0.2s
-                var speed = opts.duration;
-                var top = opts.top;
-                var left = opts.left;
+        /**
+            * Animation helper for opening the sideframe.
+            *
+            * @method _show
+            * @private
+            * @param {Object} opts
+            * @param {Number} opts.width width of the modal
+            * @param {Number} opts.height height of the modal
+            * @param {Number} opts.left left in px of the center of the modal
+            * @param {Number} opts.top top in px of the center of the modal
+            * @param {Number} opts.duration speed of opening, ms (not really used yet)
+            */
+        _show: function _show(opts) {
+            // we need to position the modal in the center
+            var that = this;
+            var width = opts.width;
+            var height = opts.height;
+            // TODO make use of transitionDuration, currently capped at 0.2s
+            var speed = opts.duration;
+            var top = opts.top;
+            var left = opts.left;
 
 
-                if (this.ui.modal.hasClass('cms-modal-open')) {
-                    this.ui.modal.addClass('cms-modal-morphing');
-                }
+            if (this.ui.modal.hasClass('cms-modal-open')) {
+                this.ui.modal.addClass('cms-modal-morphing');
+            }
 
-                this.ui.modal.css({
-                    'display': 'block',
-                    'width': width,
-                    'height': height,
-                    'top': top,
-                    'left': left,
-                    // TODO animate translateX if possible instead of margin
+            this.ui.modal.css({
+                'display': 'block',
+                'width': width,
+                'height': height,
+                'top': top,
+                'left': left,
+                // TODO animate translateX if possible instead of margin
+                'margin-left': -(width / 2),
+                'margin-top': -(height / 2)
+            });
+            // setImmediate is required to go into the next frame
+            setTimeout(function () {
+                that.ui.modal.addClass('cms-modal-open');
+            }, 0);
+
+            this.ui.modal.one('cmsTransitionEnd', function () {
+                that.ui.modal.removeClass('cms-modal-morphing');
+                that.ui.modal.css({
                     'margin-left': -(width / 2),
                     'margin-top': -(height / 2)
                 });
-                // setImmediate is required to go into the next frame
-                setTimeout(function () {
-                    that.ui.modal.addClass('cms-modal-open');
-                }, 0);
 
-                this.ui.modal.one('cmsTransitionEnd', function () {
-                    that.ui.modal.removeClass('cms-modal-morphing');
-                    that.ui.modal.css({
-                        'margin-left': -(width / 2),
-                        'margin-top': -(height / 2)
-                    });
-
-                    // check if we should maximize
-                    if (that.triggerMaximized) {
-                        that.maximize();
-                    }
-
-                    // changed locked status to allow other modals again
-                    CMS.API.locked = false;
-                    that.trigger('cms.modal.shown');
-                }).emulateTransitionEnd(speed);
-
-                // add esc close event
-                this.ui.body.off('keydown.cms.close').on('keydown.cms.close', function (e) {
-                    if (e.keyCode === CMS.KEYS.ESC) {
-                        that.options.onClose = null;
-                        that.close();
-                    }
-                });
-
-                // set focus to modal
-                this.ui.modal.focus();
-            },
-
-            /**
-             * Closes the current instance.
-             *
-             * @method close
-             */
-            close: function close() {
-                // handle refresh option
-                if (this.options.onClose) {
-                    this.reloadBrowser(this.options.onClose, false, true);
+                // check if we should maximize
+                if (that.triggerMaximized) {
+                    that.maximize();
                 }
 
-                // handle remove option when plugin is new
-                if (CMS._newPlugin) {
-                    this._deletePlugin({
-                        hideAfter: true
-                    });
-                } else {
-                    this._hide({
-                        duration: this.options.modalDuration / 2
-                    });
-                }
-            },
+                // changed locked status to allow other modals again
+                CMS.API.locked = false;
+                that.trigger('cms.modal.shown');
+            }).emulateTransitionEnd(speed);
 
-            /**
-             * Animation helper for closing the iframe.
-             *
-             * @method _hide
-             * @private
-             * @param {Object} opts
-             * @param {Number} [opts.duration=this.options.modalDuration] animation duration
-             */
-            _hide: function _hide(opts) {
-                var that = this;
-                var duration = this.options.modalDuration;
-
-                if (opts && opts.duration) {
-                    duration = opts.duration;
-                }
-
-                this.ui.frame.empty();
-                this.ui.modalBody.removeClass('cms-loader');
-                this.ui.modal.removeClass('cms-modal-open');
-                this.ui.modal.one('cmsTransitionEnd', function () {
-                    that.ui.modal.css('display', 'none');
-                }).emulateTransitionEnd(duration);
-
-                // reset maximize or minimize states for #3111
-                setTimeout(function () {
-                    if (that.minimized) {
-                        that.minimize();
-                    }
-                    if (that.maximized) {
-                        that.maximize();
-                    }
-                    that.trigger('cms.modal.closed');
-                }, this.options.duration);
-
-                this.ui.body.off('keydown.cms.close');
-            },
-
-            /**
-             * Minimizes the modal onto the toolbar.
-             *
-             * @method minimize
-             */
-            minimize: function minimize() {
-                // cancel action if maximized
-                if (this.maximized) {
-                    return false;
-                }
-
-                if (this.minimized === false) {
-                    // ensure toolbar is shown
-                    CMS.API.Toolbar.open();
-
-                    // save initial state
-                    this.ui.modal.data('css', this.ui.modal.css([
-                        'left', 'top', 'margin-left', 'margin-top'
-                    ]));
-
-                    // minimize
-                    this.ui.body.addClass('cms-modal-minimized');
-                    this.ui.modal.css({
-                        'left': this.ui.toolbarLeftPart.outerWidth(true) + 50
-                    });
-
-                    this.minimized = true;
-                } else {
-                    // maximize
-                    this.ui.body.removeClass('cms-modal-minimized');
-                    this.ui.modal.css(this.ui.modal.data('css'));
-
-                    this.minimized = false;
-                }
-            },
-
-            /**
-             * Maximizes the window according to the browser size.
-             *
-             * @method maximize
-             */
-            maximize: function maximize() {
-                // cancel action when minimized
-                if (this.minimized) {
-                    return false;
-                }
-
-                if (this.maximized === false) {
-                    // save initial state
-                    this.ui.modal.data('css', this.ui.modal.css([
-                        'left', 'top', 'margin-left', 'margin-top',
-                        'width', 'height'
-                    ]));
-
-                    this.ui.body.addClass('cms-modal-maximized');
-
-                    this.maximized = true;
-                    this.dispatchEvent('modal-maximized', { instance: this });
-                } else {
-                    // minimize
-                    this.ui.body.removeClass('cms-modal-maximized');
-                    this.ui.modal.css(this.ui.modal.data('css'));
-
-                    this.maximized = false;
-                    this.dispatchEvent('modal-restored', { instance: this });
-                }
-            },
-
-            /**
-             * Initiates the start move event from `_events`.
-             *
-             * @method _startMove
-             * @private
-             * @param {Object} pointerEvent passes starting event
-             */
-            _startMove: function _startMove(pointerEvent) {
-                // cancel if maximized or minimized
-                if (this.maximized || this.minimized) {
-                    return false;
-                }
-
-                var that = this;
-                var position = this.ui.modal.position();
-                var left;
-                var top;
-
-                this.ui.shim.show();
-
-                // create event for stopping
-                this.ui.body.on(this.pointerUp, function (e) {
-                    that._stopMove(e);
-                });
-
-                this.ui.body.on(this.pointerMove, function (e) {
-                    left = position.left - (pointerEvent.originalEvent.pageX - e.originalEvent.pageX);
-                    top = position.top - (pointerEvent.originalEvent.pageY - e.originalEvent.pageY);
-
-                    that.ui.modal.css({
-                        'left': left,
-                        'top': top
-                    });
-                }).attr('data-touch-action', 'none');
-            },
-
-            /**
-             * Initiates the stop move event from `_startResize`.
-             *
-             * @method _stopMove
-             * @private
-             */
-            _stopMove: function _stopMove() {
-                this.ui.shim.hide();
-                this.ui.body
-                    .off(this.pointerMove + ' ' + this.pointerUp)
-                    .removeAttr('data-touch-action');
-            },
-
-            /**
-             * Initiates the start resize event from `_events`.
-             *
-             * @method _startResize
-             * @private
-             * @param {Object} pointerEvent passes starting event
-             */
-            _startResize: function _startResize(pointerEvent) {
-                // cancel if in fullscreen
-                if (this.maximized) {
-                    return false;
-                }
-                // continue
-                var that = this;
-                var width = this.ui.modal.width();
-                var height = this.ui.modal.height();
-                var modalLeft = this.ui.modal.position().left;
-                var modalTop = this.ui.modal.position().top;
-
-                // create event for stopping
-                this.ui.body.on(this.pointerUp, function (e) {
-                    that._stopResize(e);
-                });
-
-                this.ui.shim.show();
-
-                this.ui.body.on(this.pointerMove, function (e) {
-                    var mvX = pointerEvent.originalEvent.pageX - e.originalEvent.pageX;
-                    var mvY = pointerEvent.originalEvent.pageY - e.originalEvent.pageY;
-                    var w = width - (mvX * 2);
-                    var h = height - (mvY * 2);
-                    var wMin = that.options.minWidth;
-                    var hMin = that.options.minHeight;
-                    var left = mvX + modalLeft;
-                    var top = mvY + modalTop;
-
-                    // add some limits
-                    if (w <= wMin) {
-                        w = wMin;
-                        left = modalLeft + width / 2 - w / 2;
-                    }
-                    if (h <= hMin) {
-                        h = hMin;
-                        top = modalTop + height / 2 - h / 2;
-                    }
-
-                    // set centered animation
-                    that.ui.modal.css({
-                        width: w,
-                        height: h,
-                        left: left,
-                        top: top
-                    });
-                }).attr('data-touch-action', 'none');
-            },
-
-            /**
-             * Initiates the stop resize event from `_startResize`.
-             *
-             * @method _stopResize
-             * @private
-             */
-            _stopResize: function _stopResize() {
-                this.ui.shim.hide();
-                this.ui.body
-                    .off(this.pointerMove + ' ' + this.pointerUp)
-                    .removeAttr('data-touch-action');
-            },
-
-            /**
-             * Sets the breadcrumb inside the modal.
-             *
-             * @method _setBreadcrumb
-             * @private
-             * @param {Object[]} breadcrumbs renderes breadcrumb on modal
-             */
-            _setBreadcrumb: function _setBreadcrumb(breadcrumbs) {
-                var crumb = '';
-                var template = '<a href="{1}" class="{2}"><span>{3}</span></a>';
-
-                // cancel if there is no breadcrumbs)
-                if (!breadcrumbs || breadcrumbs.length <= 1) {
-                    return false;
-                }
-                if (!breadcrumbs[0].title) {
-                    return false;
-                }
-
-                // add class to modal
-                this.ui.modal.addClass('cms-modal-has-breadcrumb');
-
-                // load breadcrumbs
-                $.each(breadcrumbs, function (index, item) {
-                    // check if the item is the last one
-                    var last = (index >= breadcrumbs.length - 1) ? 'active' : '';
-                    // render breadcrumbs
-                    crumb += template
-                        .replace('{1}', item.url)
-                        .replace('{2}', last)
-                        .replace('{3}', item.title);
-                });
-
-                // attach elements
-                this.ui.breadcrumb.html(crumb);
-            },
-
-            /**
-             * Sets the buttons inside the modal.
-             *
-             * @method _setButtons
-             * @private
-             * @param {jQuery} iframe loaded iframe element
-             */
-            _setButtons: function _setButtons(iframe) {
-                var djangoSuit = iframe.contents().find('.suit-columns').length > 0;
-                var that = this;
-                var group = $('<div class="cms-modal-item-buttons"></div>');
-                var render = $('<div class="cms-modal-buttons-inner"></div>');
-                var cancel = $('<a href="#" class="cms-btn">' + CMS.config.lang.cancel + '</a>');
-                var row;
-                var tmp;
-
-                if (!djangoSuit) {
-                    row = iframe.contents().find('.submit-row:eq(0)');
-                } else {
-                    row = iframe.contents().find('.save-box:eq(0)');
-                }
-                var form = iframe.contents().find('form');
-                //avoids conflict between the browser's form validation and Django's validation
-                form.on('submit', function () {
-                    // default submit button was clicked
-                    // meaning, if you have save - it should close the iframe,
-                    // if you hit save and continue editing it should be default form behaviour
-                    if (that.hideFrame) {
-                        that.ui.modal.find('.cms-modal-frame iframe').hide();
-                        // page has been saved, run checkup
-                        that.saved = true;
-                    }
-                });
-                var buttons = row.find('input, a, button');
-                // these are the buttons _inside_ the iframe
-                // we need to listen to this click event to support submitting
-                // a form by pressing enter inside of a field
-                // click is actually triggered by submit
-                buttons.on('click', function () {
-                    if ($(this).hasClass('default')) {
-                        that.hideFrame = true;
-                    }
-                });
-
-                // hide all submit-rows
-                iframe.contents().find('.submit-row').hide();
-
-                // if there are no given buttons within the submit-row area
-                // scan deeper within the form itself
-                if (!buttons.length) {
-                    row = iframe.contents().find('body:not(.change-list) #content form:eq(0)');
-                    buttons = row.find('input[type="submit"], button[type="submit"]');
-                    buttons.addClass('deletelink').hide();
-                }
-
-                // loop over input buttons
-                buttons.each(function (index, item) {
-                    item = $(item);
-                    item.attr('data-rel', '_' + index);
-
-                    // cancel if item is a hidden input
-                    if (item.attr('type') === 'hidden') {
-                        return false;
-                    }
-
-                    var title = item.attr('value') || item.text();
-                    var cls = 'cms-btn';
-
-                    if (item.is('button')) {
-                        title = item.text();
-                    }
-
-                    // set additional special css classes
-                    if (item.hasClass('default')) {
-                        cls = 'cms-btn cms-btn-action';
-                    }
-                    if (item.hasClass('deletelink')) {
-                        cls = 'cms-btn cms-btn-caution';
-                    }
-
-                    var el = $('<a href="#" class="' + cls + ' ' + item.attr('class') + '">' + title + '</a>');
-
-                    el.on(that.click + ' ' + that.touchEnd, function (e) {
-                        e.preventDefault();
-
-                        if (item.is('a')) {
-                            that._loadIframe({
-                                url: item.prop('href'),
-                                name: title
-                            });
-                        }
-
-                        // trigger only when blue action buttons are triggered
-                        if (item.hasClass('default') || item.hasClass('deletelink')) {
-                            if (!item.hasClass('default')) { // hide iframe when using buttons other than submit
-                                that.ui.modal.find('.cms-modal-frame iframe').hide();
-                                // page has been saved or deleted, run checkup
-                                that.saved = true;
-                            } else { // submit button uses the form's submit event
-                                that.hideFrame = true;
-                            }
-                        }
-
-                        if (item.is('input') || item.is('button')) {
-                            // we need to use native `.click()` event specifically
-                            // as we are inside an iframe and magic is happening
-                            item[0].click();
-                        }
-
-                    });
-                    el.wrap(group);
-
-                    // append element
-                    render.append(el.parent());
-                });
-
-                // manually add cancel button at the end
-                cancel.on(that.click, function (e) {
-                    e.preventDefault();
-                    that.options.onClose = false;
+            // add esc close event
+            this.ui.body.off('keydown.cms.close').on('keydown.cms.close', function (e) {
+                if (e.keyCode === CMS.KEYS.ESC) {
+                    that.options.onClose = null;
                     that.close();
-                });
-                cancel.wrap(group);
-                render.append(cancel.parent());
-
-                // prepare groups
-                render.find('.cms-btn-group').unwrap();
-                tmp = render.find('.cms-btn-group').clone(true, true);
-                render.find('.cms-btn-group').remove();
-                render.append(tmp.wrapAll(group.clone().addClass('cms-modal-item-buttons-left')).parent());
-
-                // render buttons
-                this.ui.modalButtons.html(render);
-            },
-
-            /**
-             * Version where the modal loads an iframe.
-             *
-             * @method _loadIframe
-             * @private
-             * @param {Object} opts
-             * @param {String} opts.url url to render iframe, takes presedence over opts.html
-             * @param {Object[]} [opts.breadcrumbs] collection of breadcrumb items
-             * @param {String} [opts.title] modal window main title (bold)
-             */
-            _loadIframe: function _loadIframe(opts) {
-                var that = this;
-
-                opts.url = this.makeURL(opts.url);
-                opts.title = opts.title || '';
-                opts.breadcrumbs = opts.breadcrumbs || '';
-
-                // show loader
-                CMS.API.Toolbar.showLoader();
-
-                // set classes
-                this.ui.modal.removeClass('cms-modal-markup');
-                this.ui.modal.addClass('cms-modal-iframe');
-
-                // we need to render the breadcrumb
-                this._setBreadcrumb(opts.breadcrumbs);
-
-                // now refresh the content
-                var holder = this.ui.frame;
-                var iframe = $('<iframe src="' + opts.url + '" class="" frameborder="0" />');
-
-                // set correct title
-                var titlePrefix = this.ui.titlePrefix;
-                var titleSuffix = this.ui.titleSuffix;
-
-                iframe.css('visibility', 'hidden');
-                titlePrefix.text(opts.title || '');
-                titleSuffix.text('');
-
-                // ensure previous iframe is hidden
-                holder.find('iframe').css('visibility', 'hidden');
-                that.ui.modalBody.addClass('cms-loader');
-
-                // attach load event for iframe to prevent flicker effects
-                iframe.on('load', function () {
-                    var messages;
-                    var messageList;
-                    var contents;
-                    var body;
-                    var innerTitle;
-                    var bc;
-
-                    // check if iframe can be accessed
-                    try {
-                        iframe.contents();
-                    } catch (error) {
-                        CMS.API.Messages.open({
-                            message: '<strong>' + error + '</strong>',
-                            error: true
-                        });
-                        that.close();
-                    }
-
-                    CMS.Modal._setupCtrlEnterSave(document);
-                    CMS.Modal._setupCtrlEnterSave(iframe[0].contentWindow.document);
-                    // for ckeditor we need to go deeper
-                    if (iframe[0].contentWindow.CMS && iframe[0].contentWindow.CMS.CKEditor) {
-                        $(iframe[0].contentWindow.document).ready(function () {
-                            // setTimeout is required to battle CKEditor initialisation
-                            setTimeout(function () {
-                                var editor = iframe[0].contentWindow.CMS.CKEditor.editor;
-                                if (editor) {
-                                    editor.on('loaded', function (e) {
-                                        CMS.Modal._setupCtrlEnterSave(
-                                            $(e.editor.container.$).find('iframe')[0].contentWindow.document
-                                        );
-                                    });
-                                }
-                            }, 100);
-                        });
-                    }
-
-                    // hide loader
-                    CMS.API.Toolbar.hideLoader();
-
-                    // show messages in toolbar if provided
-                    messageList = iframe.contents().find('.messagelist');
-                    messages = messageList.find('li');
-                    if (messages.length) {
-                        CMS.API.Messages.open({
-                            message: messages.eq(0).text()
-                        });
-                    }
-                    messageList.remove();
-                    contents = iframe.contents();
-                    body = contents.find('body');
-
-                    // inject css class
-                    body.addClass('cms-admin cms-admin-modal');
-
-                    // determine if we should close the modal or reload
-                    if (messages.length && that.enforceReload) {
-                        that.reloadBrowser();
-                    }
-                    if (messages.length && that.enforceClose) {
-                        that.close();
-                        return false;
-                    }
-
-                    // adding django hacks
-                    contents.find('.viewsitelink').attr('target', '_top');
-
-                    // set modal buttons
-                    that._setButtons($(this));
-
-                    // when an error occurs, reset the saved status so the form can be checked and validated again
-                    if (iframe.contents().find('.errornote').length || iframe.contents().find('.errorlist').length) {
-                        that.saved = false;
-                    }
-
-                    // when the window has been changed pressing the blue or red button, we need to run a reload check
-                    // also check that no delete-confirmation is required
-                    if (that.saved && !contents.find('.delete-confirmation').length) {
-                        that.reloadBrowser(
-                            that.options.onClose ? that.options.onClose : window.location.href,
-                            false,
-                            true
-                        );
-                    } else {
-                        iframe.show();
-                        // set title of not provided
-                        innerTitle = iframe.contents().find('#content h1:eq(0)');
-
-                        // case when there is no prefix
-                        if (opts.title === undefined && that.ui.titlePrefix.text() === '') {
-                            bc = iframe.contents().find('.breadcrumbs').contents();
-                            that.ui.titlePrefix.text(bc.eq(bc.length - 1).text().replace('›', '').trim());
-                        }
-
-                        if (titlePrefix.text().trim() === '') {
-                            titlePrefix.text(innerTitle.text());
-                        } else {
-                            titleSuffix.text(innerTitle.text());
-                        }
-                        innerTitle.remove();
-
-                        // than show
-                        iframe.css('visibility', 'visible');
-
-                        // append ready state
-                        iframe.data('ready', true);
-
-                        // attach close event
-                        body.on('keydown.cms', function (e) {
-                            if (e.keyCode === CMS.KEYS.ESC) {
-                                that.close();
-                            }
-                        });
-
-                        // figure out if .object-tools is available
-                        if (contents.find('.object-tools').length) {
-                            contents.find('#content').css('padding-top', 38);
-                        }
-                    }
-                });
-
-                // inject
-                holder.html(iframe);
-            },
-
-            /**
-             * Version where the modal loads an url within an iframe.
-             *
-             * @method _changeIframe
-             * @private
-             * @param {jQuery} el originated element
-             */
-            _changeIframe: function _changeIframe(el) {
-                if (el.hasClass('active')) {
-                    return false;
                 }
+            });
 
-                var parents = el.parent().find('a');
-                parents.removeClass('active');
-
-                el.addClass('active');
-
-                this._loadIframe({
-                    url: el.attr('href')
-                });
-
-                this.ui.titlePrefix.text(el.text());
-            },
-
-            /**
-             * Version where the modal loads html markup.
-             *
-             * @method _loadMarkup
-             * @private
-             * @param {Object} opts
-             * @param {String|HTMLNode|jQuery} opts.html html markup to render
-             * @param {String} opts.title modal window main title (bold)
-             * @param {String} [opts.subtitle] modal window secondary title (normal)
-             */
-            _loadMarkup: function _loadMarkup(opts) {
-                this.ui.modal.removeClass('cms-modal-iframe');
-                this.ui.modal.addClass('cms-modal-markup');
-                this.ui.modalBody.removeClass('cms-loader');
-
-                // set content
-                // empty to remove events, append to keep events
-                this.ui.frame.empty().append(opts.html);
-                this.ui.titlePrefix.text(opts.title || '');
-                this.ui.titleSuffix.text(opts.subtitle || '');
-            },
-
-            /**
-             * _deletePlugin removes a plugin once created when clicking
-             * on delete or the close item. If we don't do this, an empty
-             * plugin is generated
-             * https://github.com/divio/django-cms/pull/4381 will eventually
-             * provide a better solution
-             *
-             * @method _deletePlugin
-             * @private
-             * @param {Object} [opts] general objects element that holds settings
-             * @param {Boolean} [opts.hideAfter] hides the modal after the ajax requests succeeds
-             */
-            _deletePlugin: function _deletePlugin(opts) {
-                var that = this;
-                var data = CMS._newPlugin;
-                var post = '{ "csrfmiddlewaretoken": "' + CMS.config.csrf + '" }';
-                var text = CMS.config.lang.confirmEmpty.replace(
-                    '{1}', CMS._newPlugin.breadcrumb[CMS._newPlugin.breadcrumb.length - 1].title
-                );
-
-                // trigger an ajax request
-                return CMS.API.Toolbar.openAjax({
-                    url: data['delete'],
-                    post: post,
-                    text: text,
-                    callback: function () {
-                        CMS._newPlugin = false;
-                        if (opts && opts.hideAfter) {
-                            that._hide({
-                                duration: 100
-                            });
-                        }
-                    }
-                });
-            }
-        });
+            // set focus to modal
+            this.ui.modal.focus();
+        },
 
         /**
-         * Sets up keyup/keydown listeners so you're able to save whatever you're
-         * editing inside of an iframe by pressing `ctrl + enter` on windows and `cmd + enter` on mac.
-         *
-         * It only works with default button (e.g. action), not the `delete` button,
-         * even though sometimes it's the only actionable button in the modal.
-         *
-         * @method _setupCtrlEnterSave
-         * @private
-         * @static
-         * @param {HTMLElement} document document element (iframe or parent window);
-         */
-        CMS.Modal._setupCtrlEnterSave = function _setupCtrlEnterSave(doc) {
-            var cmdPressed = false;
-            var mac = (navigator.platform.toLowerCase().indexOf('mac') + 1);
+            * Closes the current instance.
+            *
+            * @method close
+            */
+        close: function close() {
+            // handle refresh option
+            if (this.options.onClose) {
+                this.reloadBrowser(this.options.onClose, false, true);
+            }
 
-            $(doc).on('keydown.cms.submit', function (e) {
-                if (e.ctrlKey && e.keyCode === CMS.KEYS.ENTER && !mac) {
-                    $('.cms-modal-buttons .cms-btn-action:first').trigger('click');
+            // handle remove option when plugin is new
+            if (CMS._newPlugin) {
+                this._deletePlugin({
+                    hideAfter: true
+                });
+            } else {
+                this._hide({
+                    duration: this.options.modalDuration / 2
+                });
+            }
+        },
+
+        /**
+            * Animation helper for closing the iframe.
+            *
+            * @method _hide
+            * @private
+            * @param {Object} opts
+            * @param {Number} [opts.duration=this.options.modalDuration] animation duration
+            */
+        _hide: function _hide(opts) {
+            var that = this;
+            var duration = this.options.modalDuration;
+
+            if (opts && opts.duration) {
+                duration = opts.duration;
+            }
+
+            this.ui.frame.empty();
+            this.ui.modalBody.removeClass('cms-loader');
+            this.ui.modal.removeClass('cms-modal-open');
+            this.ui.modal.one('cmsTransitionEnd', function () {
+                that.ui.modal.css('display', 'none');
+            }).emulateTransitionEnd(duration);
+
+            // reset maximize or minimize states for #3111
+            setTimeout(function () {
+                if (that.minimized) {
+                    that.minimize();
+                }
+                if (that.maximized) {
+                    that.maximize();
+                }
+                that.trigger('cms.modal.closed');
+            }, this.options.duration);
+
+            this.ui.body.off('keydown.cms.close');
+        },
+
+        /**
+            * Minimizes the modal onto the toolbar.
+            *
+            * @method minimize
+            */
+        minimize: function minimize() {
+            // cancel action if maximized
+            if (this.maximized) {
+                return false;
+            }
+
+            if (this.minimized === false) {
+                // ensure toolbar is shown
+                CMS.API.Toolbar.open();
+
+                // save initial state
+                this.ui.modal.data('css', this.ui.modal.css([
+                    'left', 'top', 'margin-left', 'margin-top'
+                ]));
+
+                // minimize
+                this.ui.body.addClass('cms-modal-minimized');
+                this.ui.modal.css({
+                    'left': this.ui.toolbarLeftPart.outerWidth(true) + 50
+                });
+
+                this.minimized = true;
+            } else {
+                // maximize
+                this.ui.body.removeClass('cms-modal-minimized');
+                this.ui.modal.css(this.ui.modal.data('css'));
+
+                this.minimized = false;
+            }
+        },
+
+        /**
+            * Maximizes the window according to the browser size.
+            *
+            * @method maximize
+            */
+        maximize: function maximize() {
+            // cancel action when minimized
+            if (this.minimized) {
+                return false;
+            }
+
+            if (this.maximized === false) {
+                // save initial state
+                this.ui.modal.data('css', this.ui.modal.css([
+                    'left', 'top', 'margin-left', 'margin-top',
+                    'width', 'height'
+                ]));
+
+                this.ui.body.addClass('cms-modal-maximized');
+
+                this.maximized = true;
+                this.dispatchEvent('modal-maximized', { instance: this });
+            } else {
+                // minimize
+                this.ui.body.removeClass('cms-modal-maximized');
+                this.ui.modal.css(this.ui.modal.data('css'));
+
+                this.maximized = false;
+                this.dispatchEvent('modal-restored', { instance: this });
+            }
+        },
+
+        /**
+            * Initiates the start move event from `_events`.
+            *
+            * @method _startMove
+            * @private
+            * @param {Object} pointerEvent passes starting event
+            */
+        _startMove: function _startMove(pointerEvent) {
+            // cancel if maximized or minimized
+            if (this.maximized || this.minimized) {
+                return false;
+            }
+
+            var that = this;
+            var position = this.ui.modal.position();
+            var left;
+            var top;
+
+            this.ui.shim.show();
+
+            // create event for stopping
+            this.ui.body.on(this.pointerUp, function (e) {
+                that._stopMove(e);
+            });
+
+            this.ui.body.on(this.pointerMove, function (e) {
+                left = position.left - (pointerEvent.originalEvent.pageX - e.originalEvent.pageX);
+                top = position.top - (pointerEvent.originalEvent.pageY - e.originalEvent.pageY);
+
+                that.ui.modal.css({
+                    'left': left,
+                    'top': top
+                });
+            }).attr('data-touch-action', 'none');
+        },
+
+        /**
+            * Initiates the stop move event from `_startResize`.
+            *
+            * @method _stopMove
+            * @private
+            */
+        _stopMove: function _stopMove() {
+            this.ui.shim.hide();
+            this.ui.body
+                .off(this.pointerMove + ' ' + this.pointerUp)
+                .removeAttr('data-touch-action');
+        },
+
+        /**
+            * Initiates the start resize event from `_events`.
+            *
+            * @method _startResize
+            * @private
+            * @param {Object} pointerEvent passes starting event
+            */
+        _startResize: function _startResize(pointerEvent) {
+            // cancel if in fullscreen
+            if (this.maximized) {
+                return false;
+            }
+            // continue
+            var that = this;
+            var width = this.ui.modal.width();
+            var height = this.ui.modal.height();
+            var modalLeft = this.ui.modal.position().left;
+            var modalTop = this.ui.modal.position().top;
+
+            // create event for stopping
+            this.ui.body.on(this.pointerUp, function (e) {
+                that._stopResize(e);
+            });
+
+            this.ui.shim.show();
+
+            this.ui.body.on(this.pointerMove, function (e) {
+                var mvX = pointerEvent.originalEvent.pageX - e.originalEvent.pageX;
+                var mvY = pointerEvent.originalEvent.pageY - e.originalEvent.pageY;
+                var w = width - (mvX * 2);
+                var h = height - (mvY * 2);
+                var wMin = that.options.minWidth;
+                var hMin = that.options.minHeight;
+                var left = mvX + modalLeft;
+                var top = mvY + modalTop;
+
+                // add some limits
+                if (w <= wMin) {
+                    w = wMin;
+                    left = modalLeft + width / 2 - w / 2;
+                }
+                if (h <= hMin) {
+                    h = hMin;
+                    top = modalTop + height / 2 - h / 2;
                 }
 
-                if (mac) {
-                    if (e.keyCode === CMS.KEYS.CMD_LEFT ||
-                        e.keyCode === CMS.KEYS.CMD_RIGHT ||
-                        e.keyCode === CMS.KEYS.CMD_FIREFOX) {
-                        cmdPressed = true;
+                // set centered animation
+                that.ui.modal.css({
+                    width: w,
+                    height: h,
+                    left: left,
+                    top: top
+                });
+            }).attr('data-touch-action', 'none');
+        },
+
+        /**
+            * Initiates the stop resize event from `_startResize`.
+            *
+            * @method _stopResize
+            * @private
+            */
+        _stopResize: function _stopResize() {
+            this.ui.shim.hide();
+            this.ui.body
+                .off(this.pointerMove + ' ' + this.pointerUp)
+                .removeAttr('data-touch-action');
+        },
+
+        /**
+            * Sets the breadcrumb inside the modal.
+            *
+            * @method _setBreadcrumb
+            * @private
+            * @param {Object[]} breadcrumbs renderes breadcrumb on modal
+            */
+        _setBreadcrumb: function _setBreadcrumb(breadcrumbs) {
+            var crumb = '';
+            var template = '<a href="{1}" class="{2}"><span>{3}</span></a>';
+
+            // cancel if there is no breadcrumbs)
+            if (!breadcrumbs || breadcrumbs.length <= 1) {
+                return false;
+            }
+            if (!breadcrumbs[0].title) {
+                return false;
+            }
+
+            // add class to modal
+            this.ui.modal.addClass('cms-modal-has-breadcrumb');
+
+            // load breadcrumbs
+            $.each(breadcrumbs, function (index, item) {
+                // check if the item is the last one
+                var last = (index >= breadcrumbs.length - 1) ? 'active' : '';
+                // render breadcrumbs
+                crumb += template
+                    .replace('{1}', item.url)
+                    .replace('{2}', last)
+                    .replace('{3}', item.title);
+            });
+
+            // attach elements
+            this.ui.breadcrumb.html(crumb);
+        },
+
+        /**
+            * Sets the buttons inside the modal.
+            *
+            * @method _setButtons
+            * @private
+            * @param {jQuery} iframe loaded iframe element
+            */
+        _setButtons: function _setButtons(iframe) {
+            var djangoSuit = iframe.contents().find('.suit-columns').length > 0;
+            var that = this;
+            var group = $('<div class="cms-modal-item-buttons"></div>');
+            var render = $('<div class="cms-modal-buttons-inner"></div>');
+            var cancel = $('<a href="#" class="cms-btn">' + CMS.config.lang.cancel + '</a>');
+            var row;
+            var tmp;
+
+            if (!djangoSuit) {
+                row = iframe.contents().find('.submit-row:eq(0)');
+            } else {
+                row = iframe.contents().find('.save-box:eq(0)');
+            }
+            var form = iframe.contents().find('form');
+            //avoids conflict between the browser's form validation and Django's validation
+            form.on('submit', function () {
+                // default submit button was clicked
+                // meaning, if you have save - it should close the iframe,
+                // if you hit save and continue editing it should be default form behaviour
+                if (that.hideFrame) {
+                    that.ui.modal.find('.cms-modal-frame iframe').hide();
+                    // page has been saved, run checkup
+                    that.saved = true;
+                }
+            });
+            var buttons = row.find('input, a, button');
+            // these are the buttons _inside_ the iframe
+            // we need to listen to this click event to support submitting
+            // a form by pressing enter inside of a field
+            // click is actually triggered by submit
+            buttons.on('click', function () {
+                if ($(this).hasClass('default')) {
+                    that.hideFrame = true;
+                }
+            });
+
+            // hide all submit-rows
+            iframe.contents().find('.submit-row').hide();
+
+            // if there are no given buttons within the submit-row area
+            // scan deeper within the form itself
+            if (!buttons.length) {
+                row = iframe.contents().find('body:not(.change-list) #content form:eq(0)');
+                buttons = row.find('input[type="submit"], button[type="submit"]');
+                buttons.addClass('deletelink').hide();
+            }
+
+            // loop over input buttons
+            buttons.each(function (index, item) {
+                item = $(item);
+                item.attr('data-rel', '_' + index);
+
+                // cancel if item is a hidden input
+                if (item.attr('type') === 'hidden') {
+                    return false;
+                }
+
+                var title = item.attr('value') || item.text();
+                var cls = 'cms-btn';
+
+                if (item.is('button')) {
+                    title = item.text();
+                }
+
+                // set additional special css classes
+                if (item.hasClass('default')) {
+                    cls = 'cms-btn cms-btn-action';
+                }
+                if (item.hasClass('deletelink')) {
+                    cls = 'cms-btn cms-btn-caution';
+                }
+
+                var el = $('<a href="#" class="' + cls + ' ' + item.attr('class') + '">' + title + '</a>');
+
+                el.on(that.click + ' ' + that.touchEnd, function (e) {
+                    e.preventDefault();
+
+                    if (item.is('a')) {
+                        that._loadIframe({
+                            url: item.prop('href'),
+                            name: title
+                        });
                     }
 
-                    if (e.keyCode === CMS.KEYS.ENTER && cmdPressed) {
-                        $('.cms-modal-buttons .cms-btn-action:first').trigger('click');
+                    // trigger only when blue action buttons are triggered
+                    if (item.hasClass('default') || item.hasClass('deletelink')) {
+                        if (!item.hasClass('default')) { // hide iframe when using buttons other than submit
+                            that.ui.modal.find('.cms-modal-frame iframe').hide();
+                            // page has been saved or deleted, run checkup
+                            that.saved = true;
+                        } else { // submit button uses the form's submit event
+                            that.hideFrame = true;
+                        }
                     }
+
+                    if (item.is('input') || item.is('button')) {
+                        // we need to use native `.click()` event specifically
+                        // as we are inside an iframe and magic is happening
+                        item[0].click();
+                    }
+
+                });
+                el.wrap(group);
+
+                // append element
+                render.append(el.parent());
+            });
+
+            // manually add cancel button at the end
+            cancel.on(that.click, function (e) {
+                e.preventDefault();
+                that.options.onClose = false;
+                that.close();
+            });
+            cancel.wrap(group);
+            render.append(cancel.parent());
+
+            // prepare groups
+            render.find('.cms-btn-group').unwrap();
+            tmp = render.find('.cms-btn-group').clone(true, true);
+            render.find('.cms-btn-group').remove();
+            render.append(tmp.wrapAll(group.clone().addClass('cms-modal-item-buttons-left')).parent());
+
+            // render buttons
+            this.ui.modalButtons.html(render);
+        },
+
+        /**
+            * Version where the modal loads an iframe.
+            *
+            * @method _loadIframe
+            * @private
+            * @param {Object} opts
+            * @param {String} opts.url url to render iframe, takes presedence over opts.html
+            * @param {Object[]} [opts.breadcrumbs] collection of breadcrumb items
+            * @param {String} [opts.title] modal window main title (bold)
+            */
+        _loadIframe: function _loadIframe(opts) {
+            var that = this;
+
+            opts.url = this.makeURL(opts.url);
+            opts.title = opts.title || '';
+            opts.breadcrumbs = opts.breadcrumbs || '';
+
+            // show loader
+            CMS.API.Toolbar.showLoader();
+
+            // set classes
+            this.ui.modal.removeClass('cms-modal-markup');
+            this.ui.modal.addClass('cms-modal-iframe');
+
+            // we need to render the breadcrumb
+            this._setBreadcrumb(opts.breadcrumbs);
+
+            // now refresh the content
+            var holder = this.ui.frame;
+            var iframe = $('<iframe src="' + opts.url + '" class="" frameborder="0" />');
+
+            // set correct title
+            var titlePrefix = this.ui.titlePrefix;
+            var titleSuffix = this.ui.titleSuffix;
+
+            iframe.css('visibility', 'hidden');
+            titlePrefix.text(opts.title || '');
+            titleSuffix.text('');
+
+            // ensure previous iframe is hidden
+            holder.find('iframe').css('visibility', 'hidden');
+            that.ui.modalBody.addClass('cms-loader');
+
+            // attach load event for iframe to prevent flicker effects
+            iframe.on('load', function () {
+                var messages;
+                var messageList;
+                var contents;
+                var body;
+                var innerTitle;
+                var bc;
+
+                // check if iframe can be accessed
+                try {
+                    iframe.contents();
+                } catch (error) {
+                    CMS.API.Messages.open({
+                        message: '<strong>' + error + '</strong>',
+                        error: true
+                    });
+                    that.close();
                 }
-            }).on('keyup.cms.submit', function (e) {
-                if (mac) {
-                    if (e.keyCode === CMS.KEYS.CMD_LEFT || e.keyCode === CMS.KEYS.CMD_RIGHT) {
-                        cmdPressed = false;
+
+                CMS.Modal._setupCtrlEnterSave(document);
+                CMS.Modal._setupCtrlEnterSave(iframe[0].contentWindow.document);
+                // for ckeditor we need to go deeper
+                if (iframe[0].contentWindow.CMS && iframe[0].contentWindow.CMS.CKEditor) {
+                    $(iframe[0].contentWindow.document).ready(function () {
+                        // setTimeout is required to battle CKEditor initialisation
+                        setTimeout(function () {
+                            var editor = iframe[0].contentWindow.CMS.CKEditor.editor;
+                            if (editor) {
+                                editor.on('loaded', function (e) {
+                                    CMS.Modal._setupCtrlEnterSave(
+                                        $(e.editor.container.$).find('iframe')[0].contentWindow.document
+                                    );
+                                });
+                            }
+                        }, 100);
+                    });
+                }
+
+                // hide loader
+                CMS.API.Toolbar.hideLoader();
+
+                // show messages in toolbar if provided
+                messageList = iframe.contents().find('.messagelist');
+                messages = messageList.find('li');
+                if (messages.length) {
+                    CMS.API.Messages.open({
+                        message: messages.eq(0).text()
+                    });
+                }
+                messageList.remove();
+                contents = iframe.contents();
+                body = contents.find('body');
+
+                // inject css class
+                body.addClass('cms-admin cms-admin-modal');
+
+                // determine if we should close the modal or reload
+                if (messages.length && that.enforceReload) {
+                    that.reloadBrowser();
+                }
+                if (messages.length && that.enforceClose) {
+                    that.close();
+                    return false;
+                }
+
+                // adding django hacks
+                contents.find('.viewsitelink').attr('target', '_top');
+
+                // set modal buttons
+                that._setButtons($(this));
+
+                // when an error occurs, reset the saved status so the form can be checked and validated again
+                if (iframe.contents().find('.errornote').length || iframe.contents().find('.errorlist').length) {
+                    that.saved = false;
+                }
+
+                // when the window has been changed pressing the blue or red button, we need to run a reload check
+                // also check that no delete-confirmation is required
+                if (that.saved && !contents.find('.delete-confirmation').length) {
+                    that.reloadBrowser(
+                        that.options.onClose ? that.options.onClose : window.location.href,
+                        false,
+                        true
+                    );
+                } else {
+                    iframe.show();
+                    // set title of not provided
+                    innerTitle = iframe.contents().find('#content h1:eq(0)');
+
+                    // case when there is no prefix
+                    if (opts.title === undefined && that.ui.titlePrefix.text() === '') {
+                        bc = iframe.contents().find('.breadcrumbs').contents();
+                        that.ui.titlePrefix.text(bc.eq(bc.length - 1).text().replace('›', '').trim());
+                    }
+
+                    if (titlePrefix.text().trim() === '') {
+                        titlePrefix.text(innerTitle.text());
+                    } else {
+                        titleSuffix.text(innerTitle.text());
+                    }
+                    innerTitle.remove();
+
+                    // than show
+                    iframe.css('visibility', 'visible');
+
+                    // append ready state
+                    iframe.data('ready', true);
+
+                    // attach close event
+                    body.on('keydown.cms', function (e) {
+                        if (e.keyCode === CMS.KEYS.ESC) {
+                            that.close();
+                        }
+                    });
+
+                    // figure out if .object-tools is available
+                    if (contents.find('.object-tools').length) {
+                        contents.find('#content').css('padding-top', 38);
                     }
                 }
             });
 
-        };
+            // inject
+            holder.html(iframe);
+        },
+
+        /**
+            * Version where the modal loads an url within an iframe.
+            *
+            * @method _changeIframe
+            * @private
+            * @param {jQuery} el originated element
+            */
+        _changeIframe: function _changeIframe(el) {
+            if (el.hasClass('active')) {
+                return false;
+            }
+
+            var parents = el.parent().find('a');
+            parents.removeClass('active');
+
+            el.addClass('active');
+
+            this._loadIframe({
+                url: el.attr('href')
+            });
+
+            this.ui.titlePrefix.text(el.text());
+        },
+
+        /**
+            * Version where the modal loads html markup.
+            *
+            * @method _loadMarkup
+            * @private
+            * @param {Object} opts
+            * @param {String|HTMLNode|jQuery} opts.html html markup to render
+            * @param {String} opts.title modal window main title (bold)
+            * @param {String} [opts.subtitle] modal window secondary title (normal)
+            */
+        _loadMarkup: function _loadMarkup(opts) {
+            this.ui.modal.removeClass('cms-modal-iframe');
+            this.ui.modal.addClass('cms-modal-markup');
+            this.ui.modalBody.removeClass('cms-loader');
+
+            // set content
+            // empty to remove events, append to keep events
+            this.ui.frame.empty().append(opts.html);
+            this.ui.titlePrefix.text(opts.title || '');
+            this.ui.titleSuffix.text(opts.subtitle || '');
+        },
+
+        /**
+            * _deletePlugin removes a plugin once created when clicking
+            * on delete or the close item. If we don't do this, an empty
+            * plugin is generated
+            * https://github.com/divio/django-cms/pull/4381 will eventually
+            * provide a better solution
+            *
+            * @method _deletePlugin
+            * @private
+            * @param {Object} [opts] general objects element that holds settings
+            * @param {Boolean} [opts.hideAfter] hides the modal after the ajax requests succeeds
+            */
+        _deletePlugin: function _deletePlugin(opts) {
+            var that = this;
+            var data = CMS._newPlugin;
+            var post = '{ "csrfmiddlewaretoken": "' + CMS.config.csrf + '" }';
+            var text = CMS.config.lang.confirmEmpty.replace(
+                '{1}', CMS._newPlugin.breadcrumb[CMS._newPlugin.breadcrumb.length - 1].title
+            );
+
+            // trigger an ajax request
+            return CMS.API.Toolbar.openAjax({
+                url: data['delete'],
+                post: post,
+                text: text,
+                callback: function () {
+                    CMS._newPlugin = false;
+                    if (opts && opts.hideAfter) {
+                        that._hide({
+                            duration: 100
+                        });
+                    }
+                }
+            });
+        }
     });
+
+    /**
+        * Sets up keyup/keydown listeners so you're able to save whatever you're
+        * editing inside of an iframe by pressing `ctrl + enter` on windows and `cmd + enter` on mac.
+        *
+        * It only works with default button (e.g. action), not the `delete` button,
+        * even though sometimes it's the only actionable button in the modal.
+        *
+        * @method _setupCtrlEnterSave
+        * @private
+        * @static
+        * @param {HTMLElement} document document element (iframe or parent window);
+        */
+    CMS.Modal._setupCtrlEnterSave = function _setupCtrlEnterSave(doc) {
+        var cmdPressed = false;
+        var mac = (navigator.platform.toLowerCase().indexOf('mac') + 1);
+
+        $(doc).on('keydown.cms.submit', function (e) {
+            if (e.ctrlKey && e.keyCode === CMS.KEYS.ENTER && !mac) {
+                $('.cms-modal-buttons .cms-btn-action:first').trigger('click');
+            }
+
+            if (mac) {
+                if (e.keyCode === CMS.KEYS.CMD_LEFT ||
+                    e.keyCode === CMS.KEYS.CMD_RIGHT ||
+                    e.keyCode === CMS.KEYS.CMD_FIREFOX) {
+                    cmdPressed = true;
+                }
+
+                if (e.keyCode === CMS.KEYS.ENTER && cmdPressed) {
+                    $('.cms-modal-buttons .cms-btn-action:first').trigger('click');
+                }
+            }
+        }).on('keyup.cms.submit', function (e) {
+            if (mac) {
+                if (e.keyCode === CMS.KEYS.CMD_LEFT || e.keyCode === CMS.KEYS.CMD_RIGHT) {
+                    cmdPressed = false;
+                }
+            }
+        });
+
+    };
 
 })(CMS.$);

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -15,14 +15,14 @@ var CMS = window.CMS || {};
     'use strict';
 
     /**
-        * The modal is triggered via API calls from the backend either
-        * through the toolbar navigation or from plugins. The APIs allow to
-        * open content from a url (iframe) or inject html directly.
-        *
-        * @class Modal
-        * @namespace CMS
-        * @uses CMS.API.Helpers
-        */
+     * The modal is triggered via API calls from the backend either
+     * through the toolbar navigation or from plugins. The APIs allow to
+     * open content from a url (iframe) or inject html directly.
+     *
+     * @class Modal
+     * @namespace CMS
+     * @uses CMS.API.Helpers
+     */
     CMS.Modal = new CMS.Class({
 
         implement: [CMS.API.Helpers],
@@ -60,11 +60,11 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Setup event pubsub mechanism for the instance.
-            *
-            * @private
-            * @method _setupEventEmitter
-            */
+         * Setup event pubsub mechanism for the instance.
+         *
+         * @private
+         * @method _setupEventEmitter
+         */
         _setupEventEmitter: function _setupEventEmitter() {
             var that = this;
             var bus = $({});
@@ -83,11 +83,11 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Stores all jQuery references within `this.ui`.
-            *
-            * @method _setupUI
-            * @private
-            */
+         * Stores all jQuery references within `this.ui`.
+         *
+         * @method _setupUI
+         * @private
+         */
         _setupUI: function _setupUI() {
             var modal = $('.cms-modal');
             this.ui = {
@@ -111,11 +111,11 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Sets up all the event handlers, such as maximize/minimize and resizing.
-            *
-            * @method _events
-            * @private
-            */
+         * Sets up all the event handlers, such as maximize/minimize and resizing.
+         *
+         * @method _events
+         * @private
+         */
         _events: function _events() {
             var that = this;
 
@@ -162,19 +162,19 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Opens the modal either in an iframe or renders markup.
-            *
-            * @method open
-            * @chainable
-            * @param {Object} opts either `opts.url` or `opts.html` are required
-            * @param {Object[]} [opts.breadcrumbs] collection of breadcrumb items
-            * @param {String|HTMLNode|jQuery} [opts.html] html markup to render
-            * @param {String} [opts.title] modal window main title (bold)
-            * @param {String} [opts.subtitle] modal window secondary title (normal)
-            * @param {String} [opts.url] url to render iframe, takes precedence over `opts.html`
-            * @param {Number} [opts.width] sets the width of the modal
-            * @param {Number} [opts.height] sets the height of the modal
-            */
+         * Opens the modal either in an iframe or renders markup.
+         *
+         * @method open
+         * @chainable
+         * @param {Object} opts either `opts.url` or `opts.html` are required
+         * @param {Object[]} [opts.breadcrumbs] collection of breadcrumb items
+         * @param {String|HTMLNode|jQuery} [opts.html] html markup to render
+         * @param {String} [opts.title] modal window main title (bold)
+         * @param {String} [opts.subtitle] modal window secondary title (normal)
+         * @param {String} [opts.url] url to render iframe, takes precedence over `opts.html`
+         * @param {Number} [opts.width] sets the width of the modal
+         * @param {Number} [opts.height] sets the height of the modal
+         */
         open: function open(opts) {
             // setup internals
             if (!(opts && opts.url || opts && opts.html)) {
@@ -257,14 +257,14 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Calculates coordinates and dimensions for modal placement
-            *
-            * @method _calculateNewPosition
-            * @private
-            * @param {Object} [opts]
-            * @param {Number} [opts.width] desired width of the modal
-            * @param {Number} [opts.height] desired height of the modal
-            */
+         * Calculates coordinates and dimensions for modal placement
+         *
+         * @method _calculateNewPosition
+         * @private
+         * @param {Object} [opts]
+         * @param {Number} [opts.width] desired width of the modal
+         * @param {Number} [opts.height] desired height of the modal
+         */
         _calculateNewPosition: function (opts) {
             // lets set the modal width and height to the size of the browser
             var widthOffset = 300; // adds margin left and right
@@ -317,17 +317,17 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Animation helper for opening the sideframe.
-            *
-            * @method _show
-            * @private
-            * @param {Object} opts
-            * @param {Number} opts.width width of the modal
-            * @param {Number} opts.height height of the modal
-            * @param {Number} opts.left left in px of the center of the modal
-            * @param {Number} opts.top top in px of the center of the modal
-            * @param {Number} opts.duration speed of opening, ms (not really used yet)
-            */
+         * Animation helper for opening the sideframe.
+         *
+         * @method _show
+         * @private
+         * @param {Object} opts
+         * @param {Number} opts.width width of the modal
+         * @param {Number} opts.height height of the modal
+         * @param {Number} opts.left left in px of the center of the modal
+         * @param {Number} opts.top top in px of the center of the modal
+         * @param {Number} opts.duration speed of opening, ms (not really used yet)
+         */
         _show: function _show(opts) {
             // we need to position the modal in the center
             var that = this;
@@ -388,10 +388,10 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Closes the current instance.
-            *
-            * @method close
-            */
+         * Closes the current instance.
+         *
+         * @method close
+         */
         close: function close() {
             // handle refresh option
             if (this.options.onClose) {
@@ -411,13 +411,13 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Animation helper for closing the iframe.
-            *
-            * @method _hide
-            * @private
-            * @param {Object} opts
-            * @param {Number} [opts.duration=this.options.modalDuration] animation duration
-            */
+         * Animation helper for closing the iframe.
+         *
+         * @method _hide
+         * @private
+         * @param {Object} opts
+         * @param {Number} [opts.duration=this.options.modalDuration] animation duration
+         */
         _hide: function _hide(opts) {
             var that = this;
             var duration = this.options.modalDuration;
@@ -448,10 +448,10 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Minimizes the modal onto the toolbar.
-            *
-            * @method minimize
-            */
+         * Minimizes the modal onto the toolbar.
+         *
+         * @method minimize
+         */
         minimize: function minimize() {
             // cancel action if maximized
             if (this.maximized) {
@@ -484,10 +484,10 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Maximizes the window according to the browser size.
-            *
-            * @method maximize
-            */
+         * Maximizes the window according to the browser size.
+         *
+         * @method maximize
+         */
         maximize: function maximize() {
             // cancel action when minimized
             if (this.minimized) {
@@ -516,12 +516,12 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Initiates the start move event from `_events`.
-            *
-            * @method _startMove
-            * @private
-            * @param {Object} pointerEvent passes starting event
-            */
+         * Initiates the start move event from `_events`.
+         *
+         * @method _startMove
+         * @private
+         * @param {Object} pointerEvent passes starting event
+         */
         _startMove: function _startMove(pointerEvent) {
             // cancel if maximized or minimized
             if (this.maximized || this.minimized) {
@@ -552,11 +552,11 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Initiates the stop move event from `_startResize`.
-            *
-            * @method _stopMove
-            * @private
-            */
+         * Initiates the stop move event from `_startResize`.
+         *
+         * @method _stopMove
+         * @private
+         */
         _stopMove: function _stopMove() {
             this.ui.shim.hide();
             this.ui.body
@@ -565,12 +565,12 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Initiates the start resize event from `_events`.
-            *
-            * @method _startResize
-            * @private
-            * @param {Object} pointerEvent passes starting event
-            */
+         * Initiates the start resize event from `_events`.
+         *
+         * @method _startResize
+         * @private
+         * @param {Object} pointerEvent passes starting event
+         */
         _startResize: function _startResize(pointerEvent) {
             // cancel if in fullscreen
             if (this.maximized) {
@@ -621,11 +621,11 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Initiates the stop resize event from `_startResize`.
-            *
-            * @method _stopResize
-            * @private
-            */
+         * Initiates the stop resize event from `_startResize`.
+         *
+         * @method _stopResize
+         * @private
+         */
         _stopResize: function _stopResize() {
             this.ui.shim.hide();
             this.ui.body
@@ -634,12 +634,12 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Sets the breadcrumb inside the modal.
-            *
-            * @method _setBreadcrumb
-            * @private
-            * @param {Object[]} breadcrumbs renderes breadcrumb on modal
-            */
+         * Sets the breadcrumb inside the modal.
+         *
+         * @method _setBreadcrumb
+         * @private
+         * @param {Object[]} breadcrumbs renderes breadcrumb on modal
+         */
         _setBreadcrumb: function _setBreadcrumb(breadcrumbs) {
             var crumb = '';
             var template = '<a href="{1}" class="{2}"><span>{3}</span></a>';
@@ -671,12 +671,12 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Sets the buttons inside the modal.
-            *
-            * @method _setButtons
-            * @private
-            * @param {jQuery} iframe loaded iframe element
-            */
+         * Sets the buttons inside the modal.
+         *
+         * @method _setButtons
+         * @private
+         * @param {jQuery} iframe loaded iframe element
+         */
         _setButtons: function _setButtons(iframe) {
             var djangoSuit = iframe.contents().find('.suit-columns').length > 0;
             var that = this;
@@ -806,15 +806,15 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Version where the modal loads an iframe.
-            *
-            * @method _loadIframe
-            * @private
-            * @param {Object} opts
-            * @param {String} opts.url url to render iframe, takes presedence over opts.html
-            * @param {Object[]} [opts.breadcrumbs] collection of breadcrumb items
-            * @param {String} [opts.title] modal window main title (bold)
-            */
+         * Version where the modal loads an iframe.
+         *
+         * @method _loadIframe
+         * @private
+         * @param {Object} opts
+         * @param {String} opts.url url to render iframe, takes presedence over opts.html
+         * @param {Object[]} [opts.breadcrumbs] collection of breadcrumb items
+         * @param {String} [opts.title] modal window main title (bold)
+         */
         _loadIframe: function _loadIframe(opts) {
             var that = this;
 
@@ -976,12 +976,12 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Version where the modal loads an url within an iframe.
-            *
-            * @method _changeIframe
-            * @private
-            * @param {jQuery} el originated element
-            */
+         * Version where the modal loads an url within an iframe.
+         *
+         * @method _changeIframe
+         * @private
+         * @param {jQuery} el originated element
+         */
         _changeIframe: function _changeIframe(el) {
             if (el.hasClass('active')) {
                 return false;
@@ -1000,15 +1000,15 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * Version where the modal loads html markup.
-            *
-            * @method _loadMarkup
-            * @private
-            * @param {Object} opts
-            * @param {String|HTMLNode|jQuery} opts.html html markup to render
-            * @param {String} opts.title modal window main title (bold)
-            * @param {String} [opts.subtitle] modal window secondary title (normal)
-            */
+         * Version where the modal loads html markup.
+         *
+         * @method _loadMarkup
+         * @private
+         * @param {Object} opts
+         * @param {String|HTMLNode|jQuery} opts.html html markup to render
+         * @param {String} opts.title modal window main title (bold)
+         * @param {String} [opts.subtitle] modal window secondary title (normal)
+         */
         _loadMarkup: function _loadMarkup(opts) {
             this.ui.modal.removeClass('cms-modal-iframe');
             this.ui.modal.addClass('cms-modal-markup');
@@ -1022,17 +1022,17 @@ var CMS = window.CMS || {};
         },
 
         /**
-            * _deletePlugin removes a plugin once created when clicking
-            * on delete or the close item. If we don't do this, an empty
-            * plugin is generated
-            * https://github.com/divio/django-cms/pull/4381 will eventually
-            * provide a better solution
-            *
-            * @method _deletePlugin
-            * @private
-            * @param {Object} [opts] general objects element that holds settings
-            * @param {Boolean} [opts.hideAfter] hides the modal after the ajax requests succeeds
-            */
+         * _deletePlugin removes a plugin once created when clicking
+         * on delete or the close item. If we don't do this, an empty
+         * plugin is generated
+         * https://github.com/divio/django-cms/pull/4381 will eventually
+         * provide a better solution
+         *
+         * @method _deletePlugin
+         * @private
+         * @param {Object} [opts] general objects element that holds settings
+         * @param {Boolean} [opts.hideAfter] hides the modal after the ajax requests succeeds
+         */
         _deletePlugin: function _deletePlugin(opts) {
             var that = this;
             var data = CMS._newPlugin;
@@ -1059,17 +1059,17 @@ var CMS = window.CMS || {};
     });
 
     /**
-        * Sets up keyup/keydown listeners so you're able to save whatever you're
-        * editing inside of an iframe by pressing `ctrl + enter` on windows and `cmd + enter` on mac.
-        *
-        * It only works with default button (e.g. action), not the `delete` button,
-        * even though sometimes it's the only actionable button in the modal.
-        *
-        * @method _setupCtrlEnterSave
-        * @private
-        * @static
-        * @param {HTMLElement} document document element (iframe or parent window);
-        */
+     * Sets up keyup/keydown listeners so you're able to save whatever you're
+     * editing inside of an iframe by pressing `ctrl + enter` on windows and `cmd + enter` on mac.
+     *
+     * It only works with default button (e.g. action), not the `delete` button,
+     * even though sometimes it's the only actionable button in the modal.
+     *
+     * @method _setupCtrlEnterSave
+     * @private
+     * @static
+     * @param {HTMLElement} document document element (iframe or parent window);
+     */
     CMS.Modal._setupCtrlEnterSave = function _setupCtrlEnterSave(doc) {
         var cmdPressed = false;
         var mac = (navigator.platform.toLowerCase().indexOf('mac') + 1);

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -866,6 +866,7 @@ var CMS = window.CMS || {};
                         error: true
                     });
                     that.close();
+                    return;
                 }
 
                 CMS.Modal._setupCtrlEnterSave(document);

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -869,7 +869,9 @@ var CMS = window.CMS || {};
                 }
 
                 CMS.Modal._setupCtrlEnterSave(document);
-                CMS.Modal._setupCtrlEnterSave(iframe[0].contentWindow.document);
+                if (iframe[0].contentWindow && iframe[0].contentWindow.document) {
+                    CMS.Modal._setupCtrlEnterSave(iframe[0].contentWindow.document);
+                }
                 // for ckeditor we need to go deeper
                 if (iframe[0].contentWindow.CMS && iframe[0].contentWindow.CMS.CKEditor) {
                     $(iframe[0].contentWindow.document).ready(function () {

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -873,7 +873,7 @@ var CMS = window.CMS || {};
                     CMS.Modal._setupCtrlEnterSave(iframe[0].contentWindow.document);
                 }
                 // for ckeditor we need to go deeper
-                if (iframe[0].contentWindow.CMS && iframe[0].contentWindow.CMS.CKEditor) {
+                if (iframe[0].contentWindow && iframe[0].contentWindow.CMS && iframe[0].contentWindow.CMS.CKEditor) {
                     $(iframe[0].contentWindow.document).ready(function () {
                         // setTimeout is required to battle CKEditor initialisation
                         setTimeout(function () {

--- a/cms/tests/frontend/.jshintrc
+++ b/cms/tests/frontend/.jshintrc
@@ -13,6 +13,7 @@
         "afterEach",
         "spyOn",
         "spyOnEvent",
-        "fixture"
+        "fixture",
+        "pending"
     ]
 }

--- a/cms/tests/frontend/base.conf.js
+++ b/cms/tests/frontend/base.conf.js
@@ -20,5 +20,5 @@ module.exports = {
     // because ios and ms edge are currently broken
     // because there's an issue with socket.io / karma and
     // we have to wait for releases that include https://github.com/socketio/socket.io-client/issues/898
-    sauceLabsBrowsers: b2s({ browsers: 'chrome 46, ff 41, ie 11, ie 10' })
+    sauceLabsBrowsers: b2s({ browsers: 'chrome 46, ff 41, ie 11, ie 10, safari 7' })
 };

--- a/cms/tests/frontend/base.conf.js
+++ b/cms/tests/frontend/base.conf.js
@@ -16,5 +16,9 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: b2s()
+    // limiting browsers for saucelabs here
+    // because ios and ms edge are currently broken
+    // because there's an issue with socket.io / karma and
+    // we have to wait for releases that include https://github.com/socketio/socket.io-client/issues/898
+    sauceLabsBrowsers: b2s({ browsers: 'chrome 46, ff 41, ie 11, ie 10, ios 8.1' })
 };

--- a/cms/tests/frontend/base.conf.js
+++ b/cms/tests/frontend/base.conf.js
@@ -20,5 +20,5 @@ module.exports = {
     // because ios and ms edge are currently broken
     // because there's an issue with socket.io / karma and
     // we have to wait for releases that include https://github.com/socketio/socket.io-client/issues/898
-    sauceLabsBrowsers: b2s({ browsers: 'chrome 46, ff 41, ie 11, ie 10, ios 8.1' })
+    sauceLabsBrowsers: b2s({ browsers: 'chrome 46, ff 41, ie 11, ie 10' })
 };

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -29,16 +29,6 @@ module.exports = function (config) {
         'PhantomJS': 'used for local testing'
     };
 
-    // Browsers to run on Sauce Labs
-    // Check out https://saucelabs.com/platforms for all browser/OS combos
-    if (useSauceLabs()) {
-        browsers = baseConf.sauceLabsBrowsers.reduce(function (browsers, capability) {
-            browsers[JSON.stringify(capability)] = capability;
-            browsers[JSON.stringify(capability)].base = 'SauceLabs';
-            return browsers;
-        }, {});
-    }
-
     var settings = {
         // base path that will be used to resolve all patterns (eg. files, exclude)
         basePath: '../../..',
@@ -133,15 +123,8 @@ module.exports = function (config) {
         // start these browsers
         browsers: Object.keys(browsers),
 
-        concurrency: (function () {
-            // travis
-            if (useSauceLabs()) {
-                return 3;
-            } else {
-                return Infinity;
-            }
-        })(),
-        browserNoActivityTimeout: 50 * 1000,
+        concurrency: Infinity,
+        browserNoActivityTimeout: 2 * 60 * 1000,
 
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits
@@ -151,8 +134,22 @@ module.exports = function (config) {
     // saucelabs are disabled for the moment because there are numerous connection problems
     // between travis and sauce labs
     if (useSauceLabs()) {
+
+        // Browsers to run on Sauce Labs
+        // Check out https://saucelabs.com/platforms for all browser/OS combos
+        browsers = baseConf.sauceLabsBrowsers.reduce(function (browsers, capability) {
+            browsers[JSON.stringify(capability)] = capability;
+            browsers[JSON.stringify(capability)].base = 'SauceLabs';
+            return browsers;
+        }, {});
+
+        settings.browsers = Object.keys(browsers);
+
+        settings.concurrency = 3;
+
         settings.sauceLabs = {
-            testName: baseConf.formatTaskName('Unit')
+            testName: baseConf.formatTaskName('Unit'),
+            tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || Math.random()
         };
         settings.captureTimeout = 0; // rely on SL timeout, see karma-runner/karma-sauce-launcher#37
         settings.customLaunchers = browsers;

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -145,11 +145,13 @@ module.exports = function (config) {
 
         settings.browsers = Object.keys(browsers);
 
-        settings.concurrency = 1;
+        if (process.env.CI) {
+            settings.concurrency = 5;
+        }
 
         settings.sauceLabs = {
             testName: baseConf.formatTaskName('Unit'),
-            tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || Math.random()
+            tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || String(Math.random())
         };
         settings.captureTimeout = 0; // rely on SL timeout, see karma-runner/karma-sauce-launcher#37
         settings.customLaunchers = browsers;

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -67,7 +67,13 @@ module.exports = function (config) {
 
             // fixtures
             'cms/tests/frontend/unit/fixtures/**/*.html',
-            'cms/tests/frontend/unit/html/**/*.html'
+            'cms/tests/frontend/unit/html/**/*.html',
+
+            // other static assets
+            { pattern: 'cms/static/cms/**/*.gif', watched: false, included: false, served: true },
+            { pattern: 'cms/static/cms/**/*.woff', watched: false, included: false, served: true },
+            { pattern: 'cms/static/cms/**/*.ttf', watched: false, included: false, served: true },
+            { pattern: 'cms/static/cms/**/*.eot', watched: false, included: false, served: true }
         ].concat(
             // tests themselves
             files.map(function (pattern) {

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -131,6 +131,8 @@ module.exports = function (config) {
         browsers: Object.keys(browsers),
 
         concurrency: Infinity,
+
+        // we need at least 2 minutes because things are a bit slow
         browserNoActivityTimeout: 2 * 60 * 1000,
 
         // Continuous Integration mode

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -49,6 +49,8 @@ module.exports = function (config) {
 
         // list of files / patterns to load in the browser
         files: [
+            'cms/static/cms/css/cms.base.css',
+
             // these have to be specified in order since
             // dependency loading is not handled yet
             'cms/static/cms/js/libs/jquery.min.js',

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -74,7 +74,8 @@ module.exports = function (config) {
             'cms/tests/frontend/unit/helpers/jasmine-jquery.js',
 
             // fixtures
-            'cms/tests/frontend/unit/fixtures/**/*.html'
+            'cms/tests/frontend/unit/fixtures/**/*.html',
+            'cms/tests/frontend/unit/html/**/*.html'
         ].concat(
             // tests themselves
             files.map(function (pattern) {
@@ -91,7 +92,7 @@ module.exports = function (config) {
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
             'cms/static/cms/js/modules/cms.*': ['coverage'],
-            '**/*.html': ['html2js']
+            'cms/tests/frontend/unit/fixtures/**/*.html': ['html2js']
         },
 
         // optionally, configure the reporter

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -146,13 +146,14 @@ module.exports = function (config) {
         settings.browsers = Object.keys(browsers);
 
         if (process.env.CI) {
-            settings.concurrency = 5;
+            settings.concurrency = 1;
         }
 
         settings.sauceLabs = {
             testName: baseConf.formatTaskName('Unit'),
             tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || String(Math.random())
         };
+        settings.logLevel = config.LOG_ERROR;
         settings.captureTimeout = 0; // rely on SL timeout, see karma-runner/karma-sauce-launcher#37
         settings.customLaunchers = browsers;
     }

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -146,11 +146,12 @@ module.exports = function (config) {
         settings.browsers = Object.keys(browsers);
 
         if (process.env.CI) {
-            settings.concurrency = 1;
+            settings.concurrency = 5;
         }
 
         settings.sauceLabs = {
             testName: baseConf.formatTaskName('Unit'),
+            build: 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')',
             tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER || String(Math.random())
         };
         settings.logLevel = config.LOG_ERROR;

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -145,7 +145,7 @@ module.exports = function (config) {
 
         settings.browsers = Object.keys(browsers);
 
-        settings.concurrency = 3;
+        settings.concurrency = 1;
 
         settings.sauceLabs = {
             testName: baseConf.formatTaskName('Unit'),

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -72,6 +72,7 @@ module.exports = function (config) {
             // other static assets
             { pattern: 'cms/static/cms/**/*.gif', watched: false, included: false, served: true },
             { pattern: 'cms/static/cms/**/*.woff', watched: false, included: false, served: true },
+            { pattern: 'cms/static/cms/**/*.woff2', watched: false, included: false, served: true },
             { pattern: 'cms/static/cms/**/*.ttf', watched: false, included: false, served: true },
             { pattern: 'cms/static/cms/**/*.eot', watched: false, included: false, served: true }
         ].concat(

--- a/cms/tests/frontend/unit/cms.base.test.js
+++ b/cms/tests/frontend/unit/cms.base.test.js
@@ -1,4 +1,4 @@
-/* globals jQuery, Class, $, document, window, localStorage, pending */
+/* globals jQuery, Class, $, document, window, localStorage */
 
 'use strict';
 

--- a/cms/tests/frontend/unit/cms.base.test.js
+++ b/cms/tests/frontend/unit/cms.base.test.js
@@ -1053,5 +1053,11 @@ describe('cms.base.js', function () {
                 expect(event).not.toHaveBeenPrevented();
             });
         });
+
+        describe('._getWindow()', function () {
+            it('returns window', function () {
+                expect(CMS.API.Helpers._getWindow()).toEqual(window);
+            });
+        });
     });
 });

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -189,57 +189,61 @@ describe('CMS.Modal', function () {
 
         it('applies correct state to modal controls 1', function () {
             modal.open({ html: '<div></div>' });
-            expect(modal.ui.resize).toBeVisible();
-            expect(modal.ui.minimizeButton).toBeVisible();
-            expect(modal.ui.maximizeButton).toBeVisible();
+            // here and in others we cannot use `.toBeVisible` matcher,
+            // because it uses jQuery's `:visible` selector which relies
+            // on an element having offsetWidth/offsetHeight, but
+            // Safari reports it to be 0 if an element is scaled with transform
+            expect(modal.ui.resize).toHaveCss({ display: 'block' });
+            expect(modal.ui.minimizeButton).toHaveCss({ display: 'block' });
+            expect(modal.ui.maximizeButton).toHaveCss({ display: 'block' });
         });
 
         it('applies correct state to modal controls 2', function () {
             modal = new CMS.Modal({ resizable: false });
             modal.open({ html: '<div></div>' });
-            expect(modal.ui.resize).not.toBeVisible();
-            expect(modal.ui.minimizeButton).toBeVisible();
-            expect(modal.ui.maximizeButton).toBeVisible();
+            expect(modal.ui.resize).toHaveCss({ display: 'none' });
+            expect(modal.ui.minimizeButton).toHaveCss({ display: 'block' });
+            expect(modal.ui.maximizeButton).toHaveCss({ display: 'block' });
         });
 
         it('applies correct state to modal controls 3', function () {
             modal = new CMS.Modal({ resizable: true });
             modal.open({ html: '<div></div>' });
-            expect(modal.ui.resize).toBeVisible();
-            expect(modal.ui.minimizeButton).toBeVisible();
-            expect(modal.ui.maximizeButton).toBeVisible();
+            expect(modal.ui.resize).toHaveCss({ display: 'block' });
+            expect(modal.ui.minimizeButton).toHaveCss({ display: 'block' });
+            expect(modal.ui.maximizeButton).toHaveCss({ display: 'block' });
         });
 
         it('applies correct state to modal controls 4', function () {
             modal = new CMS.Modal({ minimizable: false });
             modal.open({ html: '<div></div>' });
-            expect(modal.ui.resize).toBeVisible();
-            expect(modal.ui.minimizeButton).not.toBeVisible();
-            expect(modal.ui.maximizeButton).toBeVisible();
+            expect(modal.ui.resize).toHaveCss({ display: 'block' });
+            expect(modal.ui.minimizeButton).toHaveCss({ display: 'none' });
+            expect(modal.ui.maximizeButton).toHaveCss({ display: 'block' });
         });
 
         it('applies correct state to modal controls 5', function () {
             modal = new CMS.Modal({ minimizable: true });
             modal.open({ html: '<div></div>' });
-            expect(modal.ui.resize).toBeVisible();
-            expect(modal.ui.minimizeButton).toBeVisible();
-            expect(modal.ui.maximizeButton).toBeVisible();
+            expect(modal.ui.resize).toHaveCss({ display: 'block' });
+            expect(modal.ui.minimizeButton).toHaveCss({ display: 'block' });
+            expect(modal.ui.maximizeButton).toHaveCss({ display: 'block' });
         });
 
         it('applies correct state to modal controls 6', function () {
             modal = new CMS.Modal({ maximizable: false });
             modal.open({ html: '<div></div>' });
-            expect(modal.ui.resize).toBeVisible();
-            expect(modal.ui.minimizeButton).toBeVisible();
-            expect(modal.ui.maximizeButton).not.toBeVisible();
+            expect(modal.ui.resize).toHaveCss({ display: 'block' });
+            expect(modal.ui.minimizeButton).toHaveCss({ display: 'block' });
+            expect(modal.ui.maximizeButton).toHaveCss({ display: 'none' });
         });
 
         it('applies correct state to modal controls 7', function () {
             modal = new CMS.Modal({ maximizable: true });
             modal.open({ html: '<div></div>' });
-            expect(modal.ui.resize).toBeVisible();
-            expect(modal.ui.minimizeButton).toBeVisible();
-            expect(modal.ui.maximizeButton).toBeVisible();
+            expect(modal.ui.resize).toHaveCss({ display: 'block' });
+            expect(modal.ui.minimizeButton).toHaveCss({ display: 'block' });
+            expect(modal.ui.maximizeButton).toHaveCss({ display: 'block' });
         });
 
         it('resets minimized state if the modal was already minimized', function () {

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -15,7 +15,60 @@ describe('CMS.Modal', function () {
     });
 
     describe('instance', function () {
+        it('has ui', function (done) {
+            $(function () {
+                var modal = new CMS.Modal();
+                expect(modal.ui).toEqual(jasmine.any(Object));
+                expect(Object.keys(modal.ui)).toContain('modal');
+                expect(Object.keys(modal.ui)).toContain('body');
+                expect(Object.keys(modal.ui)).toContain('window');
+                expect(Object.keys(modal.ui)).toContain('toolbarLeftPart');
+                expect(Object.keys(modal.ui)).toContain('minimizeButton');
+                expect(Object.keys(modal.ui)).toContain('maximizeButton');
+                expect(Object.keys(modal.ui)).toContain('title');
+                expect(Object.keys(modal.ui)).toContain('titlePrefix');
+                expect(Object.keys(modal.ui)).toContain('titleSuffix');
+                expect(Object.keys(modal.ui)).toContain('resize');
+                expect(Object.keys(modal.ui)).toContain('breadcrumb');
+                expect(Object.keys(modal.ui)).toContain('closeAndCancel');
+                expect(Object.keys(modal.ui)).toContain('modalButtons');
+                expect(Object.keys(modal.ui)).toContain('modalBody');
+                expect(Object.keys(modal.ui)).toContain('frame');
+                expect(Object.keys(modal.ui)).toContain('shim');
+                expect(Object.keys(modal.ui).length).toEqual(16);
+                done();
+            });
+        });
 
+        it('has options', function (done) {
+            $(function () {
+                var modal = new CMS.Modal();
+                expect(modal.options).toEqual({
+                    onClose: false,
+                    minHeight: 400,
+                    minWidth: 800,
+                    modalDuration: 200,
+                    newPlugin: false,
+                    resizable: true,
+                    maximizable: true,
+                    minimizable: true
+                });
+
+                var modal2 = new CMS.Modal({ minHeight: 300, minWidth: 100 });
+                expect(modal2.options).toEqual({
+                    onClose: false,
+                    minHeight: 300,
+                    minWidth: 100,
+                    modalDuration: 200,
+                    newPlugin: false,
+                    resizable: true,
+                    maximizable: true,
+                    minimizable: true
+                });
+
+                done();
+            });
+        });
     });
 
     describe('.open()', function () {

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -321,7 +321,7 @@ describe('CMS.Modal', function () {
             modal.minimize();
 
             var css = modal.ui.modal.data('css');
-            expect(css).toEqual(jasmine.any(Object))
+            expect(css).toEqual(jasmine.any(Object));
             expect(Object.keys(css)).toContain('margin-left');
             expect(Object.keys(css)).toContain('margin-top');
             expect(Object.keys(css)).toContain('top');

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -3,17 +3,28 @@
 'use strict';
 
 describe('CMS.Modal', function () {
-    it('creates a Modal class when document is ready', function (done) {
-        $(function () {
-            expect(CMS.Modal).toBeDefined();
-            done();
-        });
+    it('creates a Modal class when document is ready', function () {
+        expect(CMS.Modal).toBeDefined();
     });
 
-    it('has public methods', function (done) {
-        $(function () {
-            expect(CMS.Modal.prototype.open).toEqual(jasmine.any(Function));
-            done();
+    it('has public API', function () {
+        expect(CMS.Modal.prototype.open).toEqual(jasmine.any(Function));
+        expect(CMS.Modal.prototype.close).toEqual(jasmine.any(Function));
+        expect(CMS.Modal.prototype.minimize).toEqual(jasmine.any(Function));
+        expect(CMS.Modal.prototype.maximize).toEqual(jasmine.any(Function));
+    });
+
+    describe('instance', function () {
+
+    });
+
+    describe('.open()', function () {
+        it('opens the modal', function (done) {
+            $(function () {
+                var modal = new CMS.Modal();
+
+                done();
+            });
         });
     });
 });

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -350,6 +350,7 @@ describe('CMS.Modal', function () {
             modal.minimize();
 
             expect(modal.minimized).toEqual(false);
+            expect(modal.ui.modal).toHaveCss(modal.ui.modal.data('css'));
             expect(modal.ui.body).not.toHaveClass('cms-modal-minimized');
         });
     });

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -329,7 +329,7 @@ describe('CMS.Modal', function () {
             modal.minimize(); // restore
         });
 
-        it('doesnt minimize maximized modal', function () {
+        it('does not minimize maximized modal', function () {
             modal.maximized = true;
             expect(modal.minimize()).toEqual(false);
             expect(CMS.API.Toolbar.open).not.toHaveBeenCalled();

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -330,9 +330,28 @@ describe('CMS.Modal', function () {
             modal.minimize(); // restore
         });
 
-        it('doesnt minimize maximized modal');
+        it('doesnt minimize maximized modal', function () {
+            var modal = new CMS.Modal();
 
-        it('restores modal if it was already minimized');
+            modal.maximized = true;
+            expect(modal.minimize()).toEqual(false);
+            expect(CMS.API.Toolbar.open).not.toHaveBeenCalled();
+            expect(modal.ui.body).not.toHaveClass('cms-modal-minimized');
+        });
+
+        it('restores modal if it was already minimized', function () {
+            var modal = new CMS.Modal();
+            modal.open({ html: '<div></div>' });
+            modal.minimize();
+
+            expect(modal.minimized).toEqual(true);
+            expect(modal.ui.body).toHaveClass('cms-modal-minimized');
+
+            modal.minimize();
+
+            expect(modal.minimized).toEqual(false);
+            expect(modal.ui.body).not.toHaveClass('cms-modal-minimized');
+        });
     });
 
     describe('.maximize()', function () {

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -74,6 +74,7 @@ describe('CMS.Modal', function () {
     });
 
     describe('.open()', function () {
+        var modal;
         beforeEach(function (done) {
             fixture.load('modal.html');
             delete CMS._newPlugin;
@@ -86,6 +87,7 @@ describe('CMS.Modal', function () {
                 hideLoader: jasmine.createSpy()
             };
             $(function () {
+                modal = new CMS.Modal();
                 done();
             });
         });
@@ -95,8 +97,6 @@ describe('CMS.Modal', function () {
         });
 
         it('throws an error when no url or html options were passed', function () {
-            var modal = new CMS.Modal();
-
             expect(modal.open.bind(modal, {})).toThrowError(
                 Error, 'The arguments passed to "open" were invalid.'
             );
@@ -113,7 +113,6 @@ describe('CMS.Modal', function () {
         });
 
         it('does not open if there is a plugin creation in process', function () {
-            var modal = new CMS.Modal();
             CMS._newPlugin = true;
             spyOn(modal, '_deletePlugin').and.callFake(function () {
                 return false;
@@ -123,7 +122,6 @@ describe('CMS.Modal', function () {
         });
 
         it('confirms if the user wants to remove freshly created plugin when opening new modal', function () {
-            var modal = new CMS.Modal();
             spyOn(CMS.Navigation.prototype, 'initialize').and.callFake(function () {
                 return {};
             });
@@ -160,21 +158,15 @@ describe('CMS.Modal', function () {
         });
 
         it('should be chainable', function () {
-            var modal = new CMS.Modal();
-
             expect(modal.open({ html: '<div></div>' })).toEqual(modal);
         });
 
         it('hides the tooltip', function () {
-            var modal = new CMS.Modal();
-
             modal.open({ html: '<div></div>' });
             expect(CMS.API.Tooltip.hide).toHaveBeenCalled();
         });
 
         it('triggers load events on instance and the DOM node', function () {
-            var modal = new CMS.Modal();
-
             spyOn(modal, 'trigger');
             var spyEvent = spyOnEvent(modal.ui.modal, 'cms.modal.load');
             modal.open({ html: '<div></div>' });
@@ -185,7 +177,7 @@ describe('CMS.Modal', function () {
         });
 
         it('sets CMS._newPlugin if we are opening a plugin creation modal', function () {
-            var modal = new CMS.Modal({
+            modal = new CMS.Modal({
                 newPlugin: {
                     something: true
                 }
@@ -195,44 +187,54 @@ describe('CMS.Modal', function () {
             expect(CMS._newPlugin).toEqual({ something: true });
         });
 
-        it('applies correct state to modal controls', function () {
-            var modal;
-            modal = new CMS.Modal();
+        it('applies correct state to modal controls 1', function () {
             modal.open({ html: '<div></div>' });
             expect(modal.ui.resize).toBeVisible();
             expect(modal.ui.minimizeButton).toBeVisible();
             expect(modal.ui.maximizeButton).toBeVisible();
+        });
 
+        it('applies correct state to modal controls 2', function () {
             modal = new CMS.Modal({ resizable: false });
             modal.open({ html: '<div></div>' });
             expect(modal.ui.resize).not.toBeVisible();
             expect(modal.ui.minimizeButton).toBeVisible();
             expect(modal.ui.maximizeButton).toBeVisible();
+        });
 
+        it('applies correct state to modal controls 3', function () {
             modal = new CMS.Modal({ resizable: true });
             modal.open({ html: '<div></div>' });
             expect(modal.ui.resize).toBeVisible();
             expect(modal.ui.minimizeButton).toBeVisible();
             expect(modal.ui.maximizeButton).toBeVisible();
+        });
 
+        it('applies correct state to modal controls 4', function () {
             modal = new CMS.Modal({ minimizable: false });
             modal.open({ html: '<div></div>' });
             expect(modal.ui.resize).toBeVisible();
             expect(modal.ui.minimizeButton).not.toBeVisible();
             expect(modal.ui.maximizeButton).toBeVisible();
+        });
 
+        it('applies correct state to modal controls 5', function () {
             modal = new CMS.Modal({ minimizable: true });
             modal.open({ html: '<div></div>' });
             expect(modal.ui.resize).toBeVisible();
             expect(modal.ui.minimizeButton).toBeVisible();
             expect(modal.ui.maximizeButton).toBeVisible();
+        });
 
+        it('applies correct state to modal controls 6', function () {
             modal = new CMS.Modal({ maximizable: false });
             modal.open({ html: '<div></div>' });
             expect(modal.ui.resize).toBeVisible();
             expect(modal.ui.minimizeButton).toBeVisible();
             expect(modal.ui.maximizeButton).not.toBeVisible();
+        });
 
+        it('applies correct state to modal controls 7', function () {
             modal = new CMS.Modal({ maximizable: true });
             modal.open({ html: '<div></div>' });
             expect(modal.ui.resize).toBeVisible();
@@ -241,8 +243,6 @@ describe('CMS.Modal', function () {
         });
 
         it('resets minimized state if the modal was already minimized', function () {
-            var modal = new CMS.Modal();
-
             modal.open({ html: '<div></div>' });
             modal.minimize();
             expect(modal.minimized).toEqual(true);
@@ -256,7 +256,6 @@ describe('CMS.Modal', function () {
         });
 
         it('clears breadcrumbs and buttons if they exist', function () {
-            var modal = new CMS.Modal();
             modal.ui.modal.addClass('cms-modal-has-breadcrumb');
             modal.ui.modalButtons.html('<div>button</div>');
             modal.ui.breadcrumb.html('<div>breadcrumbs</div>');
@@ -269,6 +268,7 @@ describe('CMS.Modal', function () {
     });
 
     describe('.minimize()', function () {
+        var modal;
         beforeEach(function (done) {
             fixture.load('modal.html');
             CMS.API.Tooltip = {
@@ -280,6 +280,7 @@ describe('CMS.Modal', function () {
                 hideLoader: jasmine.createSpy()
             };
             $(function () {
+                modal = new CMS.Modal();
                 done();
             });
         });
@@ -289,8 +290,6 @@ describe('CMS.Modal', function () {
         });
 
         it('minimizes the modal', function () {
-            var modal = new CMS.Modal();
-
             expect(modal.minimized).toEqual(false);
             modal.open({ html: '<div></div>' });
             modal.minimize();
@@ -305,8 +304,6 @@ describe('CMS.Modal', function () {
         });
 
         it('opens the toolbar', function () {
-            var modal = new CMS.Modal();
-
             modal.open({ html: '<div></div>' });
             modal.minimize();
 
@@ -315,8 +312,6 @@ describe('CMS.Modal', function () {
         });
 
         it('stores the css data to be able to restore a modal', function () {
-            var modal = new CMS.Modal();
-
             modal.open({ html: '<div></div>' });
             modal.minimize();
 
@@ -331,8 +326,6 @@ describe('CMS.Modal', function () {
         });
 
         it('doesnt minimize maximized modal', function () {
-            var modal = new CMS.Modal();
-
             modal.maximized = true;
             expect(modal.minimize()).toEqual(false);
             expect(CMS.API.Toolbar.open).not.toHaveBeenCalled();
@@ -340,7 +333,6 @@ describe('CMS.Modal', function () {
         });
 
         it('restores modal if it was already minimized', function () {
-            var modal = new CMS.Modal();
             modal.open({ html: '<div></div>' });
             modal.minimize();
 

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -3,6 +3,8 @@
 'use strict';
 
 describe('CMS.Modal', function () {
+    fixture.setBase('cms/tests/frontend/unit/fixtures');
+
     it('creates a Modal class when document is ready', function () {
         expect(CMS.Modal).toBeDefined();
     });
@@ -72,12 +74,84 @@ describe('CMS.Modal', function () {
     });
 
     describe('.open()', function () {
-        it('opens the modal', function (done) {
+        beforeEach(function (done) {
+            fixture.load('modal.html');
+            CMS.API.Tooltip = {
+                hide: jasmine.createSpy()
+            };
+            CMS.API.Toolbar = {
+                showLoader: jasmine.createSpy()
+            };
             $(function () {
-                var modal = new CMS.Modal();
-
                 done();
             });
+        });
+
+        afterEach(function () {
+            fixture.cleanup();
+        });
+
+        it('throws an error when no url or html options were passed', function () {
+            var modal = new CMS.Modal();
+
+            expect(modal.open.bind(modal, {})).toThrowError(
+                Error, 'The arguments passed to "open" were invalid.'
+            );
+            expect(modal.open.bind(modal, { html: '' })).toThrowError(
+                Error, 'The arguments passed to "open" were invalid.'
+            );
+            expect(modal.open.bind(modal, { url: '' })).toThrowError(
+                Error, 'The arguments passed to "open" were invalid.'
+            );
+            expect(modal.open.bind(modal, { html: '<div></div>' })).not.toThrow();
+            expect(modal.open.bind(modal, {
+                url: '/base/cms/tests/frontend/unit/html/modal_iframe.html'
+            })).not.toThrow();
+        });
+
+        it('does not open if there is a plugin creation in process', function () {
+            var modal = new CMS.Modal();
+            CMS._newPlugin = true;
+            spyOn(modal, '_deletePlugin').and.callFake(function () {
+                return false;
+            });
+
+            expect(modal.open({ html: '<div></div>' })).toEqual(false);
+        });
+
+        it('confirms if the user wants to remove freshly created plugin when opening new modal', function () {
+            var modal = new CMS.Modal();
+            spyOn(CMS.Navigation.prototype, 'initialize').and.callFake(function () {
+                return {};
+            });
+            CMS.API.Toolbar = new CMS.Toolbar();
+            CMS._newPlugin = {
+                delete: '/delete-url',
+                breadcrumb: [{ title: 'Fresh plugin' }]
+            };
+
+            CMS.config = $.extend(CMS.config, {
+                csrf: 'custom-token',
+                lang: {
+                    confirmEmpty: 'Question about {1}?'
+                }
+            });
+
+            spyOn(modal, '_deletePlugin').and.callThrough();
+            jasmine.Ajax.install();
+            spyOn(CMS.API.Toolbar, 'openAjax').and.callThrough();
+            spyOn(CMS.API.Helpers, 'secureConfirm').and.callFake(function () {
+                return false;
+            });
+
+            expect(modal.open({ html: '<div></div>' })).toEqual(false);
+            expect(CMS.API.Toolbar.openAjax).toHaveBeenCalledWith({
+                url: '/delete-url',
+                post: '{ "csrfmiddlewaretoken": "custom-token" }',
+                text: 'Question about Fresh plugin?',
+                callback: jasmine.any(Function)
+            });
+            jasmine.Ajax.uninstall();
         });
     });
 });

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -76,11 +76,13 @@ describe('CMS.Modal', function () {
     describe('.open()', function () {
         beforeEach(function (done) {
             fixture.load('modal.html');
+            delete CMS._newPlugin;
             CMS.API.Tooltip = {
                 hide: jasmine.createSpy()
             };
             CMS.API.Toolbar = {
-                showLoader: jasmine.createSpy()
+                showLoader: jasmine.createSpy(),
+                hideLoader: jasmine.createSpy()
             };
             $(function () {
                 done();
@@ -152,6 +154,87 @@ describe('CMS.Modal', function () {
                 callback: jasmine.any(Function)
             });
             jasmine.Ajax.uninstall();
+        });
+
+        it('should be chainable', function () {
+            var modal = new CMS.Modal();
+
+            expect(modal.open({ html: '<div></div>' })).toEqual(modal);
+        });
+
+        it('hides the tooltip', function () {
+            var modal = new CMS.Modal();
+
+            modal.open({ html: '<div></div>' });
+            expect(CMS.API.Tooltip.hide).toHaveBeenCalled();
+        });
+
+        it('triggers load events on instance and the DOM node', function () {
+            var modal = new CMS.Modal();
+
+            spyOn(modal, 'trigger');
+            var spyEvent = spyOnEvent(modal.ui.modal, 'cms.modal.load');
+            modal.open({ html: '<div></div>' });
+
+            expect(modal.trigger).toHaveBeenCalledWith('cms.modal.load');
+            expect(spyEvent).toHaveBeenTriggered();
+            expect(modal.trigger).toHaveBeenCalledWith('cms.modal.loaded');
+        });
+
+        it('sets CMS._newPlugin if we are opening a plugin creation modal', function () {
+            var modal = new CMS.Modal({
+                newPlugin: {
+                    something: true
+                }
+            });
+
+            modal.open({ html: '<div></div>' });
+            expect(CMS._newPlugin).toEqual({ something: true });
+        });
+
+        it('applies correct state to modal controls', function () {
+            var modal;
+            modal = new CMS.Modal();
+            modal.open({ html: '<div></div>' });
+            expect(modal.ui.resize).toBeVisible();
+            expect(modal.ui.minimizeButton).toBeVisible();
+            expect(modal.ui.maximizeButton).toBeVisible();
+
+            modal = new CMS.Modal({ resizable: false });
+            modal.open({ html: '<div></div>' });
+            expect(modal.ui.resize).not.toBeVisible();
+            expect(modal.ui.minimizeButton).toBeVisible();
+            expect(modal.ui.maximizeButton).toBeVisible();
+
+            modal = new CMS.Modal({ resizable: true });
+            modal.open({ html: '<div></div>' });
+            expect(modal.ui.resize).toBeVisible();
+            expect(modal.ui.minimizeButton).toBeVisible();
+            expect(modal.ui.maximizeButton).toBeVisible();
+
+            modal = new CMS.Modal({ minimizable: false });
+            modal.open({ html: '<div></div>' });
+            expect(modal.ui.resize).toBeVisible();
+            expect(modal.ui.minimizeButton).not.toBeVisible();
+            expect(modal.ui.maximizeButton).toBeVisible();
+
+            modal = new CMS.Modal({ minimizable: true });
+            modal.open({ html: '<div></div>' });
+            expect(modal.ui.resize).toBeVisible();
+            expect(modal.ui.minimizeButton).toBeVisible();
+            expect(modal.ui.maximizeButton).toBeVisible();
+
+            modal = new CMS.Modal({ maximizable: false });
+            modal.open({ html: '<div></div>' });
+            expect(modal.ui.resize).toBeVisible();
+            expect(modal.ui.minimizeButton).toBeVisible();
+            expect(modal.ui.maximizeButton).not.toBeVisible();
+
+            modal = new CMS.Modal({ maximizable: true });
+            modal.open({ html: '<div></div>' });
+            expect(modal.ui.resize).toBeVisible();
+            expect(modal.ui.minimizeButton).toBeVisible();
+            expect(modal.ui.maximizeButton).toBeVisible();
         });
     });
 });

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -81,6 +81,7 @@ describe('CMS.Modal', function () {
                 hide: jasmine.createSpy()
             };
             CMS.API.Toolbar = {
+                open: jasmine.createSpy(),
                 showLoader: jasmine.createSpy(),
                 hideLoader: jasmine.createSpy()
             };
@@ -235,6 +236,33 @@ describe('CMS.Modal', function () {
             expect(modal.ui.resize).toBeVisible();
             expect(modal.ui.minimizeButton).toBeVisible();
             expect(modal.ui.maximizeButton).toBeVisible();
+        });
+
+        it('resets minimizaed state if the modal was already minimized', function () {
+            var modal = new CMS.Modal();
+
+            modal.open({ html: '<div></div>' });
+            modal.minimize();
+            expect(modal.minimized).toEqual(true);
+
+            spyOn(modal, 'minimize').and.callThrough();
+
+            modal.open({ html: '<span></span>' });
+            expect(modal.minimized).toEqual(false);
+            expect(modal.minimize).toHaveBeenCalled();
+            expect(modal.minimize.calls.count()).toEqual(1);
+        });
+
+        it('clears breadcrumbs and buttons if they exist', function () {
+            var modal = new CMS.Modal();
+            modal.ui.modal.addClass('cms-modal-has-breadcrumb');
+            modal.ui.modalButtons.html('<div>button</div>');
+            modal.ui.breadcrumb.html('<div>breadcrumbs</div>');
+
+            modal.open({ html: '<div></div>' });
+            expect(modal.ui.modal).not.toHaveClass('cms-modal-has-breadcrumb');
+            expect(modal.ui.modalButtons).toBeEmpty();
+            expect(modal.ui.breadcrumb).toBeEmpty();
         });
     });
 });

--- a/cms/tests/frontend/unit/cms.modal.test.js
+++ b/cms/tests/frontend/unit/cms.modal.test.js
@@ -265,4 +265,40 @@ describe('CMS.Modal', function () {
             expect(modal.ui.breadcrumb).toBeEmpty();
         });
     });
+
+    describe('.minimize()', function () {
+        beforeEach(function (done) {
+            fixture.load('modal.html');
+            CMS.API.Toolbar = {
+                open: jasmine.createSpy(),
+                showLoader: jasmine.createSpy(),
+                hideLoader: jasmine.createSpy()
+            };
+            $(function () {
+                done();
+            });
+        });
+
+        afterEach(function () {
+            fixture.clear();
+        });
+
+        it('minimizes the modal');
+
+        it('opens the toolbar');
+
+        it('stores the css data to be able to restore a modal');
+
+        it('doesnt minimize maximized modal');
+
+        it('restores modal if it was already minimized');
+    });
+
+    describe('.maximize()', function () {
+
+    });
+
+    describe('.close()', function () {
+
+    });
 });

--- a/cms/tests/frontend/unit/fixtures/modal.html
+++ b/cms/tests/frontend/unit/fixtures/modal.html
@@ -1,0 +1,20 @@
+<div class="cms-modal" data-touch-action="none">
+    <div class="cms-modal-head" data-touch-action="none">
+        <span class="cms-modal-title" data-touch-action="none">
+            <span class="cms-modal-title-prefix"></span>
+            <span class="cms-modal-title-suffix"></span>
+        </span>
+        <span class="cms-modal-minimize cms-icon cms-icon-minus" title="Minimize"></span>
+        <span class="cms-modal-maximize cms-icon cms-icon-window" title="Maximize"></span>
+        <span class="cms-modal-close cms-icon cms-icon-close" title="Close"></span>
+    </div>
+    <div class="cms-modal-breadcrumb" data-touch-action="pan-x"></div>
+    <div class="cms-modal-body">
+        <div class="cms-modal-shim"></div>
+        <div class="cms-modal-frame"></div>
+    </div>
+    <div class="cms-modal-foot">
+        <div class="cms-modal-buttons"></div>
+        <div class="cms-modal-resize"><span class="cms-icon cms-icon-handler"></span></div>
+    </div>
+</div>

--- a/cms/tests/frontend/unit/fixtures/modal.html
+++ b/cms/tests/frontend/unit/fixtures/modal.html
@@ -1,4 +1,4 @@
-<div class="cms">
+<div class="cms cms-reset">
     <div class="cms-modal" data-touch-action="none">
         <div class="cms-modal-head" data-touch-action="none">
             <span class="cms-modal-title" data-touch-action="none">

--- a/cms/tests/frontend/unit/fixtures/modal.html
+++ b/cms/tests/frontend/unit/fixtures/modal.html
@@ -1,20 +1,22 @@
-<div class="cms-modal" data-touch-action="none">
-    <div class="cms-modal-head" data-touch-action="none">
-        <span class="cms-modal-title" data-touch-action="none">
-            <span class="cms-modal-title-prefix"></span>
-            <span class="cms-modal-title-suffix"></span>
-        </span>
-        <span class="cms-modal-minimize cms-icon cms-icon-minus" title="Minimize"></span>
-        <span class="cms-modal-maximize cms-icon cms-icon-window" title="Maximize"></span>
-        <span class="cms-modal-close cms-icon cms-icon-close" title="Close"></span>
-    </div>
-    <div class="cms-modal-breadcrumb" data-touch-action="pan-x"></div>
-    <div class="cms-modal-body">
-        <div class="cms-modal-shim"></div>
-        <div class="cms-modal-frame"></div>
-    </div>
-    <div class="cms-modal-foot">
-        <div class="cms-modal-buttons"></div>
-        <div class="cms-modal-resize"><span class="cms-icon cms-icon-handler"></span></div>
+<div class="cms">
+    <div class="cms-modal" data-touch-action="none">
+        <div class="cms-modal-head" data-touch-action="none">
+            <span class="cms-modal-title" data-touch-action="none">
+                <span class="cms-modal-title-prefix"></span>
+                <span class="cms-modal-title-suffix"></span>
+            </span>
+            <span class="cms-modal-minimize cms-icon cms-icon-minus" title="Minimize"></span>
+            <span class="cms-modal-maximize cms-icon cms-icon-window" title="Maximize"></span>
+            <span class="cms-modal-close cms-icon cms-icon-close" title="Close"></span>
+        </div>
+        <div class="cms-modal-breadcrumb" data-touch-action="pan-x"></div>
+        <div class="cms-modal-body">
+            <div class="cms-modal-shim"></div>
+            <div class="cms-modal-frame"></div>
+        </div>
+        <div class="cms-modal-foot">
+            <div class="cms-modal-buttons"></div>
+            <div class="cms-modal-resize"><span class="cms-icon cms-icon-handler"></span></div>
+        </div>
     </div>
 </div>

--- a/cms/tests/frontend/unit/html/modal_iframe.html
+++ b/cms/tests/frontend/unit/html/modal_iframe.html
@@ -1,0 +1,1 @@
+<div>I am an iframe</div>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19,7 +19,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "lodash@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
@@ -471,7 +471,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -546,7 +546,7 @@
             },
             "caniuse-db": {
               "version": "1.0.30000375",
-              "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+              "from": "caniuse-db@>=1.0.30000335 <2.0.0",
               "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000375.tgz"
             }
           }
@@ -587,7 +587,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -626,7 +626,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -664,7 +664,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -740,7 +740,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "from": "ansi-regex@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -752,7 +752,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "from": "ansi-regex@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -1337,7 +1337,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -1961,7 +1961,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
@@ -2772,7 +2772,7 @@
                         },
                         "isstream": {
                           "version": "0.1.2",
-                          "from": "isstream@>=0.1.0 <0.2.0",
+                          "from": "isstream@>=0.1.2 <0.2.0",
                           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                         },
                         "is-typedarray": {
@@ -4162,7 +4162,7 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.0.33 <2.0.0",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
@@ -4338,7 +4338,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -4784,7 +4784,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.3",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.0 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -4812,9 +4812,9 @@
                                       }
                                     },
                                     "lazy-cache": {
-                                      "version": "0.2.5",
+                                      "version": "0.2.6",
                                       "from": "lazy-cache@>=0.2.4 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.5.tgz"
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.6.tgz"
                                     }
                                   }
                                 },
@@ -5211,7 +5211,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.1",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
                     },
                     "event-emitter": {
@@ -5243,7 +5243,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.1",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
                     }
                   }
@@ -5600,7 +5600,7 @@
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.0 <0.3.0",
+                      "from": "async@>=0.2.9 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
@@ -5807,7 +5807,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -5981,7 +5981,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "lodash@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "minimatch": {
@@ -6027,7 +6027,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -6109,7 +6109,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -6189,7 +6189,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -6888,7 +6888,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -6977,7 +6977,7 @@
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "from": "nopt@>=3.0.1 <3.1.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                   "dependencies": {
                     "abbrev": {
@@ -7134,7 +7134,7 @@
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@>=0.0.0 <1.0.0",
+                  "from": "osenv@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
@@ -7182,7 +7182,7 @@
                   "dependencies": {
                     "glob": {
                       "version": "5.0.15",
-                      "from": "glob@>=5.0.1 <6.0.0",
+                      "from": "glob@>=5.0.14 <6.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
@@ -7751,7 +7751,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -7790,7 +7790,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -7843,7 +7843,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -7911,7 +7911,7 @@
         },
         "fancy-log": {
           "version": "1.1.0",
-          "from": "fancy-log@>=1.0.0 <2.0.0",
+          "from": "fancy-log@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
           "dependencies": {
             "chalk": {
@@ -8065,7 +8065,7 @@
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -8311,7 +8311,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -8358,7 +8358,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -8386,9 +8386,9 @@
                           }
                         },
                         "lazy-cache": {
-                          "version": "0.2.5",
+                          "version": "0.2.6",
                           "from": "lazy-cache@>=0.2.4 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.5.tgz"
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.6.tgz"
                         }
                       }
                     },
@@ -8399,7 +8399,7 @@
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
@@ -8500,7 +8500,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -8536,7 +8536,7 @@
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "dateformat@>=1.0.6 <2.0.0",
+          "from": "dateformat@>=1.0.11 <2.0.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "dependencies": {
             "get-stdin": {
@@ -8913,7 +8913,7 @@
           "dependencies": {
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@>=0.0.2 <0.1.0",
+              "from": "duplexer2@0.0.2",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
@@ -8959,12 +8959,12 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -9037,7 +9037,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
@@ -9409,9 +9409,9 @@
                       }
                     },
                     "lazy-cache": {
-                      "version": "0.2.5",
+                      "version": "0.2.6",
                       "from": "lazy-cache@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.5.tgz"
+                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.6.tgz"
                     },
                     "normalize-path": {
                       "version": "2.0.1",
@@ -9526,7 +9526,7 @@
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.10 <3.0.0",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
@@ -9619,6 +9619,11 @@
                   "from": "ansi@~0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                 },
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
                 "ansi-styles": {
                   "version": "2.1.0",
                   "from": "ansi-styles@^2.1.0",
@@ -9628,11 +9633,6 @@
                   "version": "1.0.4",
                   "from": "are-we-there-yet@~1.0.0",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
-                },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
@@ -9864,11 +9864,6 @@
                   "from": "lodash._createpadding@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
                 },
-                "lodash.pad": {
-                  "version": "3.1.1",
-                  "from": "lodash.pad@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
-                },
                 "lodash.padleft": {
                   "version": "3.1.1",
                   "from": "lodash.padleft@^3.0.0",
@@ -9878,6 +9873,11 @@
                   "version": "3.1.1",
                   "from": "lodash.padright@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                },
+                "lodash.pad": {
+                  "version": "3.1.1",
+                  "from": "lodash.pad@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
                 },
                 "lodash.repeat": {
                   "version": "3.0.1",
@@ -9944,15 +9944,15 @@
                   "from": "qs@~5.2.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                 },
-                "request": {
-                  "version": "2.65.0",
-                  "from": "request@2.x",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
-                },
                 "readable-stream": {
                   "version": "1.1.13",
                   "from": "readable-stream@^1.1.13",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+                },
+                "request": {
+                  "version": "2.65.0",
+                  "from": "request@2.x",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
                 },
                 "semver": {
                   "version": "5.0.3",
@@ -10063,15 +10063,15 @@
                       "from": "glob@>=5.0.14 <6.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
                     },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-                    },
                     "once": {
                       "version": "1.3.2",
                       "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
                     }
                   }
                 },
@@ -10208,7 +10208,7 @@
                 },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@1.0.0",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
@@ -10305,7 +10305,7 @@
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.0 <5.1.0",
+          "from": "glob@>=5.0.10 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
@@ -10327,7 +10327,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
@@ -10368,7 +10368,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "lodash@>=3.8.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "log4js": {
@@ -10383,7 +10383,7 @@
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "from": "readable-stream@>=1.0.26 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -11242,9 +11242,9 @@
                                   }
                                 },
                                 "lazy-cache": {
-                                  "version": "0.2.5",
+                                  "version": "0.2.6",
                                   "from": "lazy-cache@>=0.2.4 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.5.tgz"
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.6.tgz"
                                 }
                               }
                             },
@@ -11350,7 +11350,7 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "from": "nopt@>=3.0.0 <4.0.0",
+              "from": "nopt@>=3.0.1 <3.1.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
             },
             "once": {
@@ -11410,7 +11410,7 @@
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "dateformat@>=1.0.6 <2.0.0",
+          "from": "dateformat@>=1.0.11 <2.0.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "dependencies": {
             "get-stdin": {
@@ -11966,7 +11966,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
@@ -12007,7 +12007,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
+          "from": "lodash@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
@@ -12018,10 +12018,152 @@
       "resolved": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.1.2.tgz"
     },
     "karma-sauce-launcher": {
-      "version": "0.2.14",
-      "from": "karma-sauce-launcher@0.2.14",
-      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.2.14.tgz",
+      "version": "0.3.0",
+      "from": "karma-sauce-launcher@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.0.tgz",
       "dependencies": {
+        "q": {
+          "version": "1.4.1",
+          "from": "q@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+        },
+        "sauce-connect-launcher": {
+          "version": "0.13.0",
+          "from": "sauce-connect-launcher@>=0.13.0 <0.14.0",
+          "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.13.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "async": {
+              "version": "1.4.0",
+              "from": "async@1.4.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
+            },
+            "adm-zip": {
+              "version": "0.4.7",
+              "from": "adm-zip@>=0.4.3 <0.5.0",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
+            },
+            "rimraf": {
+              "version": "2.4.3",
+              "from": "rimraf@2.4.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "glob@>=5.0.14 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.2",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "saucelabs": {
+          "version": "1.0.1",
+          "from": "saucelabs@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
+          "dependencies": {
+            "https-proxy-agent": {
+              "version": "1.0.0",
+              "from": "https-proxy-agent@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+              "dependencies": {
+                "agent-base": {
+                  "version": "2.0.1",
+                  "from": "agent-base@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+                  "dependencies": {
+                    "semver": {
+                      "version": "5.0.3",
+                      "from": "semver@>=5.0.1 <5.1.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
         "wd": {
           "version": "0.3.12",
           "from": "wd@>=0.3.4 <0.4.0",
@@ -12156,7 +12298,7 @@
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <1.4.0",
+                          "from": "once@>=1.3.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
@@ -12210,11 +12352,6 @@
               "version": "3.9.3",
               "from": "lodash@>=3.9.3 <3.10.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-            },
-            "q": {
-              "version": "1.4.1",
-              "from": "q@>=1.4.1 <1.5.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
             },
             "request": {
               "version": "2.55.0",
@@ -12407,7 +12544,7 @@
                     },
                     "chalk": {
                       "version": "1.1.1",
-                      "from": "chalk@>=1.1.1 <2.0.0",
+                      "from": "chalk@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "dependencies": {
                         "ansi-styles": {
@@ -12512,43 +12649,6 @@
               "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz"
             }
           }
-        },
-        "sauce-connect-launcher": {
-          "version": "0.11.1",
-          "from": "sauce-connect-launcher@>=0.11.1 <0.12.0",
-          "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.11.1.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "3.5.0",
-              "from": "lodash@3.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
-            },
-            "async": {
-              "version": "0.9.0",
-              "from": "async@0.9.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-            },
-            "adm-zip": {
-              "version": "0.4.7",
-              "from": "adm-zip@>=0.4.3 <0.5.0",
-              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
-            },
-            "rimraf": {
-              "version": "2.2.6",
-              "from": "rimraf@2.2.6",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
-            }
-          }
-        },
-        "q": {
-          "version": "0.9.7",
-          "from": "q@>=0.9.6 <0.10.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
-        },
-        "saucelabs": {
-          "version": "0.1.1",
-          "from": "saucelabs@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
         }
       }
     },
@@ -12765,7 +12865,7 @@
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "from": "semver@>=4.1.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uid-number": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,9 +2,8 @@
   "name": "djangoCMS",
   "dependencies": {
     "browserslist-saucelabs": {
-      "version": "0.2.3",
+      "version": "0.2.4",
       "from": "browserslist-saucelabs@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/browserslist-saucelabs/-/browserslist-saucelabs-0.2.3.tgz",
       "dependencies": {
         "browserslist": {
           "version": "1.0.1",
@@ -12,15 +11,15 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
           "dependencies": {
             "caniuse-db": {
-              "version": "1.0.30000372",
-              "from": "caniuse-db@>=1.0.30000335 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000372.tgz"
+              "version": "1.0.30000375",
+              "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000375.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.0.1 <4.0.0",
+          "from": "lodash@>=3.8.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
@@ -306,7 +305,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
@@ -546,9 +545,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000372",
+              "version": "1.0.30000375",
               "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000372.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000375.tgz"
             }
           }
         },
@@ -620,14 +619,14 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.3 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -697,7 +696,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -741,7 +740,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "from": "ansi-regex@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -753,7 +752,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "from": "ansi-regex@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -1971,9 +1970,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.3",
+                  "version": "1.0.6",
                   "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -2054,9 +2053,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.3",
+                  "version": "1.0.6",
                   "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -2387,7 +2386,7 @@
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "from": "mkdirp@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
@@ -2420,41 +2419,14 @@
                           "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                         },
                         "are-we-there-yet": {
-                          "version": "1.0.4",
+                          "version": "1.0.5",
                           "from": "are-we-there-yet@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz",
                           "dependencies": {
                             "delegates": {
                               "version": "0.1.0",
                               "from": "delegates@>=0.1.0 <0.2.0",
                               "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-                            },
-                            "readable-stream": {
-                              "version": "1.1.13",
-                              "from": "readable-stream@>=1.1.13 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                }
-                              }
                             }
                           }
                         },
@@ -2630,14 +2602,14 @@
                           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                         },
                         "mime-types": {
-                          "version": "2.1.7",
+                          "version": "2.1.8",
                           "from": "mime-types@>=2.1.7 <2.2.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
                           "dependencies": {
                             "mime-db": {
-                              "version": "1.19.0",
-                              "from": "mime-db@>=1.19.0 <1.20.0",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                              "version": "1.20.0",
+                              "from": "mime-db@>=1.20.0 <1.21.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
                             }
                           }
                         },
@@ -2652,9 +2624,9 @@
                           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                         },
                         "tunnel-agent": {
-                          "version": "0.4.1",
+                          "version": "0.4.2",
                           "from": "tunnel-agent@>=0.4.1 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                         },
                         "tough-cookie": {
                           "version": "2.2.1",
@@ -2694,9 +2666,9 @@
                               }
                             },
                             "sshpk": {
-                              "version": "1.7.0",
+                              "version": "1.7.1",
                               "from": "sshpk@>=1.7.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
                               "dependencies": {
                                 "asn1": {
                                   "version": "0.2.3",
@@ -3209,7 +3181,7 @@
                                     },
                                     "spdx-license-ids": {
                                       "version": "1.1.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                     }
                                   }
@@ -3620,9 +3592,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.3",
+                  "version": "1.0.6",
                   "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -3698,9 +3670,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.3",
+                  "version": "1.0.6",
                   "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -3750,7 +3722,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -3762,7 +3734,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -4325,7 +4297,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@>=1.0.33 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -4366,7 +4338,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.2 <0.7.0",
+          "from": "through2@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -4398,7 +4370,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -4812,7 +4784,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.3",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.0 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -4853,7 +4825,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.3",
-                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "from": "align-text@>=0.1.0 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -5223,9 +5195,9 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.8",
+                      "version": "0.10.9",
                       "from": "es5-ext@>=0.10.8 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.9.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.0",
@@ -5260,9 +5232,9 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.8",
+                      "version": "0.10.9",
                       "from": "es5-ext@>=0.10.8 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.9.tgz"
                     },
                     "es6-iterator": {
                       "version": "2.0.0",
@@ -5817,9 +5789,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.3",
+                  "version": "1.0.6",
                   "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -6009,7 +5981,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.0.1 <4.0.0",
+          "from": "lodash@>=3.8.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "minimatch": {
@@ -6169,7 +6141,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -6217,7 +6189,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.3 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -6298,14 +6270,14 @@
               }
             },
             "cross-spawn": {
-              "version": "2.0.1",
+              "version": "2.1.0",
               "from": "cross-spawn@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.1.0.tgz",
               "dependencies": {
                 "cross-spawn-async": {
-                  "version": "2.0.1",
+                  "version": "2.1.1",
                   "from": "cross-spawn-async@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.1.1.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "3.2.0",
@@ -6376,9 +6348,9 @@
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "process-nextick-args": {
-                              "version": "1.0.3",
+                              "version": "1.0.6",
                               "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
@@ -6621,7 +6593,7 @@
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -6905,9 +6877,9 @@
               }
             },
             "node-gyp": {
-              "version": "3.2.0",
+              "version": "3.2.1",
               "from": "node-gyp@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.2.1.tgz",
               "dependencies": {
                 "fstream": {
                   "version": "1.0.8",
@@ -6916,7 +6888,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -7026,9 +6998,9 @@
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                     },
                     "are-we-there-yet": {
-                      "version": "1.0.4",
+                      "version": "1.0.5",
                       "from": "are-we-there-yet@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz",
                       "dependencies": {
                         "delegates": {
                           "version": "0.1.0",
@@ -7036,29 +7008,39 @@
                           "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                         },
                         "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.13 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "version": "2.0.4",
+                          "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
                               "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
                             "isarray": {
                               "version": "0.0.1",
                               "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.6",
+                              "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
                               "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
                         }
@@ -7339,9 +7321,9 @@
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.3",
+                          "version": "1.0.6",
                           "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
@@ -7390,14 +7372,14 @@
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.7",
+                  "version": "2.1.8",
                   "from": "mime-types@>=2.1.7 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.19.0",
-                      "from": "mime-db@>=1.19.0 <1.20.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                      "version": "1.20.0",
+                      "from": "mime-db@>=1.20.0 <1.21.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
                     }
                   }
                 },
@@ -7412,9 +7394,9 @@
                   "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.1",
+                  "version": "0.4.2",
                   "from": "tunnel-agent@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.1",
@@ -7454,9 +7436,9 @@
                       }
                     },
                     "sshpk": {
-                      "version": "1.7.0",
+                      "version": "1.7.1",
                       "from": "sshpk@>=1.7.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
@@ -7646,51 +7628,20 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "yargs": {
-                  "version": "3.30.0",
+                  "version": "3.31.0",
                   "from": "yargs@>=3.8.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.30.0.tgz",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.31.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "2.0.1",
+                      "from": "camelcase@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
                     },
                     "cliui": {
                       "version": "3.1.0",
                       "from": "cliui@>=3.0.3 <4.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
                       "dependencies": {
-                        "string-width": {
-                          "version": "1.0.1",
-                          "from": "string-width@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.0.0",
-                              "from": "code-point-at@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
                         "strip-ansi": {
                           "version": "3.0.0",
                           "from": "strip-ansi@>=3.0.0 <4.0.0",
@@ -7734,9 +7685,52 @@
                         }
                       }
                     },
+                    "string-width": {
+                      "version": "1.0.1",
+                      "from": "string-width@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.0",
+                          "from": "code-point-at@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "window-size": {
                       "version": "0.1.4",
-                      "from": "window-size@>=0.1.2 <0.2.0",
+                      "from": "window-size@>=0.1.4 <0.2.0",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                     },
                     "y18n": {
@@ -7888,7 +7882,7 @@
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.6 <0.5.0",
+          "from": "vinyl@>=0.4.3 <0.5.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone": {
@@ -7968,7 +7962,7 @@
             },
             "dateformat": {
               "version": "1.0.12",
-              "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+              "from": "dateformat@>=1.0.11 <2.0.0",
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
               "dependencies": {
                 "get-stdin": {
@@ -8299,9 +8293,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.3",
+                  "version": "1.0.6",
                   "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -8317,7 +8311,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -8542,7 +8536,7 @@
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "dateformat@>=1.0.11 <2.0.0",
+          "from": "dateformat@>=1.0.6 <2.0.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "dependencies": {
             "get-stdin": {
@@ -9004,7 +8998,7 @@
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.6 <0.5.0",
+          "from": "vinyl@>=0.4.3 <0.5.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone": {
@@ -9022,9 +9016,9 @@
       }
     },
     "jasmine-core": {
-      "version": "2.3.4",
+      "version": "2.4.1",
       "from": "jasmine-core@>=2.3.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
     },
     "jshint-stylish": {
       "version": "2.1.0",
@@ -9122,7 +9116,7 @@
     },
     "karma": {
       "version": "0.13.15",
-      "from": "karma@latest",
+      "from": "karma@>=0.13.15 <0.14.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.15.tgz",
       "dependencies": {
         "batch": {
@@ -9207,21 +9201,31 @@
               "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
             },
             "raw-body": {
-              "version": "2.1.4",
+              "version": "2.1.5",
               "from": "raw-body@>=2.1.4 <2.2.0",
-              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
               "dependencies": {
+                "bytes": {
+                  "version": "2.2.0",
+                  "from": "bytes@2.2.0",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+                },
+                "iconv-lite": {
+                  "version": "0.4.13",
+                  "from": "iconv-lite@0.4.13",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "from": "unpipe@1.0.0",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "type-is": {
-              "version": "1.6.9",
+              "version": "1.6.10",
               "from": "type-is@>=1.6.9 <1.7.0",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
@@ -9229,14 +9233,14 @@
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.7",
-                  "from": "mime-types@>=2.1.7 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "version": "2.1.8",
+                  "from": "mime-types@>=2.1.8 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.19.0",
-                      "from": "mime-db@>=1.19.0 <1.20.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                      "version": "1.20.0",
+                      "from": "mime-db@>=1.20.0 <1.21.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
                     }
                   }
                 }
@@ -9245,9 +9249,9 @@
           }
         },
         "chokidar": {
-          "version": "1.3.0",
+          "version": "1.4.0",
           "from": "chokidar@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.0.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
@@ -9260,24 +9264,19 @@
                   "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
                 },
                 "micromatch": {
-                  "version": "2.3.3",
+                  "version": "2.3.5",
                   "from": "micromatch@>=2.1.5 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.5.tgz",
                   "dependencies": {
                     "arr-diff": {
-                      "version": "1.1.0",
-                      "from": "arr-diff@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+                      "version": "2.0.0",
+                      "from": "arr-diff@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "dependencies": {
                         "arr-flatten": {
                           "version": "1.0.1",
                           "from": "arr-flatten@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
-                        },
-                        "array-slice": {
-                          "version": "0.2.3",
-                          "from": "array-slice@>=0.2.3 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
@@ -9297,41 +9296,41 @@
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
-                              "version": "2.2.2",
+                              "version": "2.2.3",
                               "from": "fill-range@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "dependencies": {
                                 "is-number": {
-                                  "version": "1.1.2",
-                                  "from": "is-number@>=1.1.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                  "version": "2.1.0",
+                                  "from": "is-number@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                 },
                                 "isobject": {
-                                  "version": "1.0.2",
-                                  "from": "isobject@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                                  "version": "2.0.0",
+                                  "from": "isobject@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    }
+                                  }
                                 },
                                 "randomatic": {
                                   "version": "1.1.3",
-                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "from": "randomatic@>=1.1.3 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.3.tgz",
                                   "dependencies": {
-                                    "is-number": {
-                                      "version": "2.1.0",
-                                      "from": "is-number@>=2.0.2 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                       "dependencies": {
-                                        "kind-of": {
-                                          "version": "3.0.2",
-                                          "from": "kind-of@>=3.0.2 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                                          "dependencies": {
-                                            "is-buffer": {
-                                              "version": "1.1.0",
-                                              "from": "is-buffer@>=1.0.2 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                            }
-                                          }
+                                        "is-buffer": {
+                                          "version": "1.1.0",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                         }
                                       }
                                     }
@@ -9398,9 +9397,9 @@
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     },
                     "kind-of": {
-                      "version": "2.0.1",
-                      "from": "kind-of@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                      "version": "3.0.2",
+                      "from": "kind-of@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "dependencies": {
                         "is-buffer": {
                           "version": "1.1.0",
@@ -9570,9 +9569,9 @@
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.3",
+                      "version": "1.0.6",
                       "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -9615,11 +9614,6 @@
                   "from": "abbrev@1",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 },
-                "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                },
                 "ansi": {
                   "version": "0.3.0",
                   "from": "ansi@~0.3.0",
@@ -9629,6 +9623,11 @@
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@^2.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
@@ -9665,25 +9664,25 @@
                   "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@~0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                },
                 "boom": {
                   "version": "2.10.1",
                   "from": "boom@^2.8.x",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
+                },
                 "chalk": {
                   "version": "1.1.1",
                   "from": "chalk@^1.1.1",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@~0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
@@ -9710,15 +9709,15 @@
                   "from": "cryptiles@2.x.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@~0.7.2",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                },
                 "ctype": {
                   "version": "0.5.3",
                   "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@~0.7.2",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                 },
                 "deep-extend": {
                   "version": "0.2.11",
@@ -9745,11 +9744,6 @@
                   "from": "extend@~3.0.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "from": "form-data@~1.0.0-rc3",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
-                },
                 "forever-agent": {
                   "version": "0.6.1",
                   "from": "forever-agent@~0.6.1",
@@ -9759,6 +9753,11 @@
                   "version": "1.0.8",
                   "from": "fstream@^1.0.2",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "from": "form-data@~1.0.0-rc3",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
                 },
                 "gauge": {
                   "version": "1.2.2",
@@ -9815,15 +9814,15 @@
                   "from": "http-signature@~0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
                 },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
                 "inherits": {
                   "version": "2.0.1",
                   "from": "inherits@*",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "is-my-json-valid": {
                   "version": "2.12.2",
@@ -9870,30 +9869,30 @@
                   "from": "lodash.pad@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
                 },
-                "lodash.padright": {
-                  "version": "3.1.1",
-                  "from": "lodash.padright@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-                },
                 "lodash.padleft": {
                   "version": "3.1.1",
                   "from": "lodash.padleft@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                },
+                "lodash.padright": {
+                  "version": "3.1.1",
+                  "from": "lodash.padright@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
                 },
                 "lodash.repeat": {
                   "version": "3.0.1",
                   "from": "lodash.repeat@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
                 },
-                "mime-types": {
-                  "version": "2.1.7",
-                  "from": "mime-types@~2.1.7",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
-                },
                 "mime-db": {
                   "version": "1.19.0",
                   "from": "mime-db@~1.19.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "from": "mime-types@~2.1.7",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
                 },
                 "minimist": {
                   "version": "0.0.8",
@@ -9905,15 +9904,25 @@
                   "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                 },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@~1.4.3",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                "npmlog": {
+                  "version": "1.2.1",
+                  "from": "npmlog@~1.2.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
                 },
                 "once": {
                   "version": "1.1.1",
                   "from": "once@~1.1.1",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "oauth-sign@~0.8.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@~1.4.3",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
@@ -9934,11 +9943,6 @@
                   "version": "5.2.0",
                   "from": "qs@~5.2.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-                },
-                "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "oauth-sign@~0.8.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
@@ -9990,10 +9994,10 @@
                   "from": "tar@~2.2.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                 },
-                "npmlog": {
-                  "version": "1.2.1",
-                  "from": "npmlog@~1.2.0",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
+                "tough-cookie": {
+                  "version": "2.2.0",
+                  "from": "tough-cookie@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
@@ -10005,20 +10009,15 @@
                   "from": "uid-number@0.0.3",
                   "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
                 },
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                },
                 "xtend": {
                   "version": "4.0.1",
                   "from": "xtend@^4.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 },
-                "tough-cookie": {
-                  "version": "2.2.0",
-                  "from": "tough-cookie@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 },
                 "fstream-ignore": {
                   "version": "1.0.3",
@@ -10064,15 +10063,15 @@
                       "from": "glob@>=5.0.14 <6.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
                     },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-                    },
                     "once": {
                       "version": "1.3.2",
                       "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
                     }
                   }
                 },
@@ -10306,7 +10305,7 @@
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.10 <6.0.0",
+          "from": "glob@>=5.0.0 <5.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
@@ -10970,9 +10969,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         },
         "useragent": {
-          "version": "2.1.7",
+          "version": "2.1.8",
           "from": "useragent@>=2.1.6 <3.0.0",
-          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.8.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
@@ -10985,7 +10984,7 @@
     },
     "karma-coverage": {
       "version": "0.5.3",
-      "from": "karma-coverage@latest",
+      "from": "karma-coverage@>=0.5.3 <0.6.0",
       "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.5.3.tgz",
       "dependencies": {
         "istanbul": {
@@ -11356,7 +11355,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.0.0 <2.0.0",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
@@ -11497,7 +11496,7 @@
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -11514,7 +11513,7 @@
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -11735,7 +11734,7 @@
     },
     "karma-coveralls": {
       "version": "1.1.2",
-      "from": "karma-coveralls@latest",
+      "from": "karma-coveralls@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/karma-coveralls/-/karma-coveralls-1.1.2.tgz",
       "dependencies": {
         "coveralls": {
@@ -11847,9 +11846,9 @@
                   }
                 },
                 "tunnel-agent": {
-                  "version": "0.4.1",
+                  "version": "0.4.2",
                   "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
@@ -11938,7 +11937,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
@@ -12008,163 +12007,21 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.0.1 <4.0.0",
+          "from": "lodash@>=3.8.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "karma-phantomjs-shim": {
       "version": "1.1.2",
-      "from": "karma-phantomjs-shim@latest",
+      "from": "karma-phantomjs-shim@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.1.2.tgz"
     },
     "karma-sauce-launcher": {
-      "version": "0.3.0",
-      "from": "karma-sauce-launcher@latest",
-      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.0.tgz",
+      "version": "0.2.14",
+      "from": "karma-sauce-launcher@0.2.14",
+      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.2.14.tgz",
       "dependencies": {
-        "q": {
-          "version": "1.4.1",
-          "from": "q@>=1.4.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-        },
-        "sauce-connect-launcher": {
-          "version": "0.13.0",
-          "from": "sauce-connect-launcher@>=0.13.0 <0.14.0",
-          "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.13.0.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "async": {
-              "version": "1.4.0",
-              "from": "async@1.4.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
-            },
-            "adm-zip": {
-              "version": "0.4.7",
-              "from": "adm-zip@>=0.4.3 <0.5.0",
-              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
-            },
-            "rimraf": {
-              "version": "2.4.3",
-              "from": "rimraf@2.4.3",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "from": "glob@>=5.0.14 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.2",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "saucelabs": {
-          "version": "1.0.1",
-          "from": "saucelabs@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
-          "dependencies": {
-            "https-proxy-agent": {
-              "version": "1.0.0",
-              "from": "https-proxy-agent@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-              "dependencies": {
-                "agent-base": {
-                  "version": "2.0.1",
-                  "from": "agent-base@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
-                  "dependencies": {
-                    "semver": {
-                      "version": "5.0.3",
-                      "from": "semver@>=5.0.1 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "debug@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "ms@0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
         "wd": {
           "version": "0.3.12",
           "from": "wd@>=0.3.4 <0.4.0",
@@ -12299,7 +12156,7 @@
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <1.4.0",
+                          "from": "once@>=1.3.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
@@ -12353,6 +12210,11 @@
               "version": "3.9.3",
               "from": "lodash@>=3.9.3 <3.10.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+            },
+            "q": {
+              "version": "1.4.1",
+              "from": "q@>=1.4.1 <1.5.0",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
             },
             "request": {
               "version": "2.55.0",
@@ -12443,9 +12305,9 @@
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.1",
+                  "version": "0.4.2",
                   "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.1",
@@ -12650,6 +12512,43 @@
               "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz"
             }
           }
+        },
+        "sauce-connect-launcher": {
+          "version": "0.11.1",
+          "from": "sauce-connect-launcher@>=0.11.1 <0.12.0",
+          "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.11.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "3.5.0",
+              "from": "lodash@3.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "adm-zip": {
+              "version": "0.4.7",
+              "from": "adm-zip@>=0.4.3 <0.5.0",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.6",
+              "from": "rimraf@2.2.6",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@>=0.9.6 <0.10.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "saucelabs": {
+          "version": "0.1.1",
+          "from": "saucelabs@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
         }
       }
     },
@@ -12951,9 +12850,9 @@
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "tunnel-agent": {
-              "version": "0.4.1",
+              "version": "0.4.2",
               "from": "tunnel-agent@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             },
             "tough-cookie": {
               "version": "2.2.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,14 +12,14 @@
           "dependencies": {
             "caniuse-db": {
               "version": "1.0.30000375",
-              "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+              "from": "caniuse-db@>=1.0.30000335 <2.0.0",
               "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000375.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
+          "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
@@ -305,7 +305,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
@@ -471,7 +471,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -619,7 +619,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -696,7 +696,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -740,7 +740,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -752,7 +752,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -1337,7 +1337,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -1961,7 +1961,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
@@ -2386,7 +2386,7 @@
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.0.0 <1.0.0",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
@@ -2772,7 +2772,7 @@
                         },
                         "isstream": {
                           "version": "0.1.2",
-                          "from": "isstream@>=0.1.2 <0.2.0",
+                          "from": "isstream@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                         },
                         "is-typedarray": {
@@ -3722,7 +3722,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -3734,7 +3734,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -3834,7 +3834,7 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -3851,7 +3851,7 @@
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -4162,7 +4162,7 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "from": "readable-stream@>=1.0.33 <2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
@@ -4297,7 +4297,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.0.33 <2.0.0",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -4370,7 +4370,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -4784,7 +4784,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.3",
-                                      "from": "align-text@>=0.1.0 <0.2.0",
+                                      "from": "align-text@>=0.1.1 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -4812,9 +4812,9 @@
                                       }
                                     },
                                     "lazy-cache": {
-                                      "version": "0.2.4",
+                                      "version": "0.2.5",
                                       "from": "lazy-cache@>=0.2.4 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.5.tgz"
                                     }
                                   }
                                 },
@@ -4825,7 +4825,7 @@
                                   "dependencies": {
                                     "align-text": {
                                       "version": "0.1.3",
-                                      "from": "align-text@>=0.1.0 <0.2.0",
+                                      "from": "align-text@>=0.1.1 <0.2.0",
                                       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                                       "dependencies": {
                                         "kind-of": {
@@ -5211,7 +5211,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.1",
-                      "from": "es6-symbol@>=3.0.1 <3.1.0",
+                      "from": "es6-symbol@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
                     },
                     "event-emitter": {
@@ -5243,7 +5243,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.1",
-                      "from": "es6-symbol@>=3.0.1 <3.1.0",
+                      "from": "es6-symbol@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
                     }
                   }
@@ -5807,7 +5807,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -5981,7 +5981,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
+          "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "minimatch": {
@@ -6141,7 +6141,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -7182,7 +7182,7 @@
                   "dependencies": {
                     "glob": {
                       "version": "5.0.15",
-                      "from": "glob@>=5.0.14 <6.0.0",
+                      "from": "glob@>=5.0.1 <6.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
@@ -7882,7 +7882,7 @@
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "vinyl@>=0.4.6 <0.5.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone": {
@@ -8048,7 +8048,7 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -8065,7 +8065,7 @@
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -8311,7 +8311,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -8386,9 +8386,9 @@
                           }
                         },
                         "lazy-cache": {
-                          "version": "0.2.4",
+                          "version": "0.2.5",
                           "from": "lazy-cache@>=0.2.4 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.5.tgz"
                         }
                       }
                     },
@@ -8622,7 +8622,7 @@
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -8639,7 +8639,7 @@
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -8913,7 +8913,7 @@
           "dependencies": {
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@0.0.2",
+              "from": "duplexer2@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
@@ -8998,7 +8998,7 @@
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "vinyl@>=0.4.6 <0.5.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone": {
@@ -9409,9 +9409,9 @@
                       }
                     },
                     "lazy-cache": {
-                      "version": "0.2.4",
+                      "version": "0.2.5",
                       "from": "lazy-cache@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
+                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.5.tgz"
                     },
                     "normalize-path": {
                       "version": "2.0.1",
@@ -9619,11 +9619,6 @@
                   "from": "ansi@~0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                 },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                },
                 "ansi-styles": {
                   "version": "2.1.0",
                   "from": "ansi-styles@^2.1.0",
@@ -9633,6 +9628,11 @@
                   "version": "1.0.4",
                   "from": "are-we-there-yet@~1.0.0",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
+                },
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
@@ -9674,15 +9674,15 @@
                   "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
                 },
-                "chalk": {
-                  "version": "1.1.1",
-                  "from": "chalk@^1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-                },
                 "caseless": {
                   "version": "0.11.0",
                   "from": "caseless@~0.11.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                },
+                "chalk": {
+                  "version": "1.1.1",
+                  "from": "chalk@^1.1.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
@@ -9749,15 +9749,15 @@
                   "from": "forever-agent@~0.6.1",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
-                "fstream": {
-                  "version": "1.0.8",
-                  "from": "fstream@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-                },
                 "form-data": {
                   "version": "1.0.0-rc3",
                   "from": "form-data@~1.0.0-rc3",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                },
+                "fstream": {
+                  "version": "1.0.8",
+                  "from": "fstream@^1.0.2",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                 },
                 "gauge": {
                   "version": "1.2.2",
@@ -9904,25 +9904,25 @@
                   "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                 },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@~1.4.3",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
                 "npmlog": {
                   "version": "1.2.1",
                   "from": "npmlog@~1.2.0",
                   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
-                },
-                "once": {
-                  "version": "1.1.1",
-                  "from": "once@~1.1.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.8.0",
                   "from": "oauth-sign@~0.8.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@~1.4.3",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                "once": {
+                  "version": "1.1.1",
+                  "from": "once@~1.1.1",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
@@ -9944,15 +9944,15 @@
                   "from": "qs@~5.2.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                 },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@^1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                },
                 "request": {
                   "version": "2.65.0",
                   "from": "request@2.x",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@^1.1.13",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
                 },
                 "semver": {
                   "version": "5.0.3",
@@ -10009,15 +10009,15 @@
                   "from": "uid-number@0.0.3",
                   "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
                 },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@^4.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                },
                 "wrappy": {
                   "version": "1.0.1",
                   "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@^4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 },
                 "fstream-ignore": {
                   "version": "1.0.3",
@@ -10063,15 +10063,15 @@
                       "from": "glob@>=5.0.14 <6.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
                     },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
-                    },
                     "minimatch": {
                       "version": "3.0.0",
                       "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
                     }
                   }
                 },
@@ -10208,7 +10208,7 @@
                 },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "from": "unpipe@1.0.0",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
@@ -10327,7 +10327,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
@@ -10368,7 +10368,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
+          "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "log4js": {
@@ -11214,7 +11214,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.3",
-                                  "from": "align-text@>=0.1.0 <0.2.0",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                                   "dependencies": {
                                     "kind-of": {
@@ -11242,9 +11242,9 @@
                                   }
                                 },
                                 "lazy-cache": {
-                                  "version": "0.2.4",
+                                  "version": "0.2.5",
                                   "from": "lazy-cache@>=0.2.4 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.5.tgz"
                                 }
                               }
                             },
@@ -11255,7 +11255,7 @@
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.3",
-                                  "from": "align-text@>=0.1.0 <0.2.0",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                                   "dependencies": {
                                     "kind-of": {
@@ -11355,7 +11355,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
@@ -11496,7 +11496,7 @@
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -11513,7 +11513,7 @@
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -11937,7 +11937,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
@@ -11966,7 +11966,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
@@ -12007,7 +12007,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
+          "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
@@ -12156,7 +12156,7 @@
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
+                          "from": "once@>=1.3.0 <1.4.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
@@ -12407,7 +12407,7 @@
                     },
                     "chalk": {
                       "version": "1.1.1",
-                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "from": "chalk@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                       "dependencies": {
                         "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-phantomjs-shim": "^1.1.2",
-    "karma-sauce-launcher": "^0.3.0",
+    "karma-sauce-launcher": "0.2.14",
     "minimist": "1.1.1",
     "phantomjs": "^1.9.19",
     "casperjs": "^1.1.0-beta3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-phantomjs-shim": "^1.1.2",
-    "karma-sauce-launcher": "0.2.14",
+    "karma-sauce-launcher": "^0.3.0",
     "minimist": "1.1.1",
     "phantomjs": "^1.9.19",
     "casperjs": "^1.1.0-beta3"


### PR DESCRIPTION
- this PR adds some tests for cms.modal
- moves modal declaration out of document ready
- fixes tests for cms.base (apparently reassigning window.parent is not really possible in real environments)
- modifies karma config to work correctly with saucelabs on a limited amount of browsers
- adds other static files to what karma serves

so far it brings us to a 37% coverage for modal
![screen shot 2015-12-09 at 10 40 30](https://cloud.githubusercontent.com/assets/366813/11681788/63a605f0-9e61-11e5-8b27-94c0710f02dc.png)

locally i've tested with
![screen shot 2015-12-09 at 14 54 00](https://cloud.githubusercontent.com/assets/366813/11687052/d695848c-9e84-11e5-8315-0b2c9983bc79.png)


some tests for modal public methods are still missing, but they will come