### PR TITLE
revert `use saucelabs` to be `skip saucelabs`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
   # xvfb is started in this way to ensure the screen size is 1280x1024x8
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/cucumber_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x8"
   - "export TRAVIS_COMMIT_MSG=\"$(git log --format=%B --no-merges -n 1)\""
-  - echo "$TRAVIS_COMMIT_MSG" | grep '\[use saucelabs\]'; export SKIP_SAUCE_LABS=$?; true
+  - echo "$TRAVIS_COMMIT_MSG" | grep '\[skip saucelabs\]'; export USE_SAUCE_LABS=$?; true
 
 install:
   - if [ "$UNIT" != 1 ] && [ "$LINT" != 1 ]; then pip install -r "test_requirements/django-$DJANGO.txt"; pip freeze; fi

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -18,11 +18,8 @@ module.exports = function (config) {
     }
 
     var useSauceLabs = function () {
-        var val = process.env.SKIP_SAUCE_LABS;
-        return val !== undefined &&
-            val === '0' &&
-            process.env.SAUCE_USERNAME &&
-            process.env.SAUCE_ACCESS_KEY;
+        var val = process.env.USE_SAUCE_LABS;
+        return val === undefined || val !== '0' || !process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY;
     };
 
     var browsers = {

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -173,9 +173,10 @@ actual browser.
 
     INFO [karma]: Karma v0.13.15 server started at http://localhost:9876/
 
-.. todo
-
-    Describe Saucelabs integration, which is currently disabled.
+On Travis CI we are using SauceLabs integration to run tests in a set of
+different real browsers, but you can opt out of running them on saucelabs using
+``[skip saucelabs]`` marker in the commit message, similar to how you would skip
+the build entirely using ``[skip ci]``.
 
 
 Integration tests


### PR DESCRIPTION
since we figured out the issue with it, we can use it reliably now
and opt out if needed