### PR TITLE
Extend randomString helper

### DIFF
--- a/cms/tests/frontend/integration/createContent.js
+++ b/cms/tests/frontend/integration/createContent.js
@@ -8,7 +8,7 @@ var messages = require('./settings/messages').page.addContent;
 var randomString = require('./helpers/randomString').randomString;
 
 // random text string for filtering and content purposes
-var randomText = randomString(10);
+var randomText = randomString({ length: 50, withWhitespaces: true });
 
 casper.test.begin('User Add Content', function (test) {
     casper

--- a/cms/tests/frontend/integration/editContent.js
+++ b/cms/tests/frontend/integration/editContent.js
@@ -7,7 +7,7 @@ var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.editContent;
 var randomString = require('./helpers/randomString').randomString;
 // random text string for filtering and content purposes
-var randomText = randomString(10);
+var randomText = randomString({ length: 50, withWhitespaces: true });
 
 
 casper.test.begin('Edit content', function (test) {

--- a/cms/tests/frontend/integration/helpers/randomString.js
+++ b/cms/tests/frontend/integration/helpers/randomString.js
@@ -1,7 +1,20 @@
 'use strict';
 
-module.exports.randomString = function (length, onlyDigits) {
-    var stringLength = length || 6;
+/**
+ * Generates random strings
+ * @param {Number} [opts.length=6] - length of the string to produce
+ * @param {Boolean} [opts.onlyDigits=false] - make helper return string containing numbers only
+ * @param {Boolean} [opts.withWhitespaces=false] - make helper return string containing numbers only
+ *
+ * @returns {String} randomString
+ */
+module.exports.randomString = function (options) {
+    // defaults
+    options = options || {};
+    var stringLength = options.length || 6;
+    var onlyDigits = options.onlyDigits || false;
+    var withWhitespaces = options.withWhitespaces || false;
+
     var randomString = '';
     var possibleCharacters = '0123456789';
 
@@ -10,6 +23,9 @@ module.exports.randomString = function (length, onlyDigits) {
     }
     if (!onlyDigits) {
         possibleCharacters += 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+    }
+    if (withWhitespaces) {
+        possibleCharacters += ' ';
     }
     for (var i = 0; i < stringLength; i++) {
         randomString += possibleCharacters.charAt(Math.floor(Math.random() * possibleCharacters.length));

--- a/cms/tests/frontend/integration/newPage.js
+++ b/cms/tests/frontend/integration/newPage.js
@@ -7,7 +7,7 @@ var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.creation.toolbar;
 var randomString = require('./helpers/randomString').randomString;
 
-var newPageTitle = randomString({ length:50, withWhitespaces: true });
+var newPageTitle = randomString({ length: 50, withWhitespaces: true });
 
 casper.test.begin('New Page Creation', function (test) {
     casper

--- a/cms/tests/frontend/integration/newPage.js
+++ b/cms/tests/frontend/integration/newPage.js
@@ -7,7 +7,7 @@ var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.creation.toolbar;
 var randomString = require('./helpers/randomString').randomString;
 
-var newPageTitle = randomString(10);
+var newPageTitle = randomString({ length:50, withWhitespaces: true });
 
 casper.test.begin('New Page Creation', function (test) {
     casper

--- a/cms/tests/frontend/integration/switchLanguage.js
+++ b/cms/tests/frontend/integration/switchLanguage.js
@@ -7,7 +7,7 @@ var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.switchLanguage;
 var randomString = require('./helpers/randomString').randomString;
 // random text string for filtering and content purposes
-var randomText = randomString({ length:50, withWhitespaces: true });
+var randomText = randomString({ length: 50, withWhitespaces: true });
 // No Preview Template text
 var noPreviewText = 'This page has no preview';
 

--- a/cms/tests/frontend/integration/switchLanguage.js
+++ b/cms/tests/frontend/integration/switchLanguage.js
@@ -7,7 +7,7 @@ var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.switchLanguage;
 var randomString = require('./helpers/randomString').randomString;
 // random text string for filtering and content purposes
-var randomText = randomString(10);
+var randomText = randomString({ length:50, withWhitespaces: true });
 // No Preview Template text
 var noPreviewText = 'This page has no preview';
 


### PR DESCRIPTION
Extends randomString helper:
- [x] pass meaningful object instead of bunch of booleans
- [x] add option to generate strings with whitespaces (full text imitation).