### PR TITLE
cms clipboard tests

### DIFF
--- a/cms/static/cms/js/modules/cms.clipboard.js
+++ b/cms/static/cms/js/modules/cms.clipboard.js
@@ -7,6 +7,7 @@
 /**
  * @module CMS
  */
+/* istanbul ignore next */
 var CMS = window.CMS || {};
 
 // #############################################################################
@@ -14,134 +15,130 @@ var CMS = window.CMS || {};
 (function ($) {
     'use strict';
 
-    // shorthand for jQuery(document).ready();
-    $(function () {
+    /**
+     * Handles copy & paste in the structureboard.
+     *
+     * @class Clipboard
+     * @namespace CMS
+     * @uses CMS.API.Helpers
+     */
+    CMS.Clipboard = new CMS.Class({
+
+        implement: [CMS.API.Helpers],
+
+        initialize: function () {
+            this._setupUI();
+
+            // states
+            this.click = 'click.cms.clipboard';
+
+            // setup events
+            this._events();
+        },
+
         /**
-         * Handles copy & paste in the structureboard.
+         * Caches all the jQuery element queries.
          *
-         * @class Clipboard
-         * @namespace CMS
-         * @uses CMS.API.Helpers
+         * @method _setupUI
+         * @private
          */
-        CMS.Clipboard = new CMS.Class({
+        _setupUI: function _setupUI() {
+            var clipboard = $('.cms-clipboard');
+            this.ui = {
+                clipboard: clipboard,
+                triggers: $('.cms-clipboard-trigger a'),
+                triggerRemove: $('.cms-clipboard-empty a'),
+                pluginsList: clipboard.find('.cms-clipboard-containers'),
+                document: $(document)
+            };
+        },
 
-            implement: [CMS.API.Helpers],
+        /**
+         * Sets up event handlers for clipboard ui.
+         *
+         * @method _events
+         * @private
+         */
+        _events: function () {
+            var that = this;
 
-            initialize: function () {
-                this._setupUI();
+            var MIN_WIDTH = 400;
+            // FIXME kind of a magic number for 1 item in clipboard
+            var MIN_HEIGHT = 117;
 
-                // states
-                this.click = 'click.cms.clipboard';
+            that.modal = new CMS.Modal({
+                minWidth: MIN_WIDTH,
+                minHeight: MIN_HEIGHT,
+                minimizable: false,
+                maximizable: false,
+                resizable: false
+            });
 
-                // setup events
-                this._events();
-            },
+            that.modal.on('cms.modal.loaded cms.modal.closed', function removePlaceholder() {
+                // cannot be cached
+                $('.cms-add-plugin-placeholder').remove();
+            }).on('cms.modal.closed cms.modal.load', function () {
+                that.ui.pluginsList.prependTo(that.ui.clipboard);
+            }).ui.modal.on('cms.modal.load', function () {
+                that.ui.pluginsList.prependTo(that.ui.clipboard);
+            });
 
-            /**
-             * Caches all the jQuery element queries.
-             *
-             * @method _setupUI
-             * @private
-             */
-            _setupUI: function _setupUI() {
-                var clipboard = $('.cms-clipboard');
-                this.ui = {
-                    clipboard: clipboard,
-                    triggers: $('.cms-clipboard-trigger a'),
-                    triggerRemove: $('.cms-clipboard-empty a'),
-                    pluginsList: clipboard.find('.cms-clipboard-containers'),
-                    document: $(document)
-                };
-            },
+            that.ui.triggers.on(that.click, function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                if ($(this).parent().hasClass('cms-toolbar-item-navigation-disabled')) {
+                    return false;
+                }
 
-            /**
-             * Sets up event handlers for clipboard ui.
-             *
-             * @method _events
-             * @private
-             */
-            _events: function () {
-                var that = this;
-
-                var MIN_WIDTH = 400;
-                // FIXME kind of a magic number for 1 item in clipboard
-                var MIN_HEIGHT = 117;
-
-                that.modal = new CMS.Modal({
-                    minWidth: MIN_WIDTH,
-                    minHeight: MIN_HEIGHT,
-                    minimizable: false,
-                    maximizable: false,
-                    resizable: false
+                that.modal.open({
+                    html: that.ui.pluginsList,
+                    title: that.ui.clipboard.data('title'),
+                    width: MIN_WIDTH,
+                    height: MIN_HEIGHT
                 });
+                that.ui.document.trigger('click.cms.toolbar');
+            });
 
-                that.modal.on('cms.modal.loaded cms.modal.closed', function removePlaceholder() {
-                    // cannot be cached
-                    $('.cms-add-plugin-placeholder').remove();
-                }).on('cms.modal.closed cms.modal.load', function () {
-                    that.ui.pluginsList.prependTo(that.ui.clipboard);
-                }).ui.modal.on('cms.modal.load', function () {
-                    that.ui.pluginsList.prependTo(that.ui.clipboard);
-                });
-
-                that.ui.triggers.on(that.click, function (e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if ($(this).parent().hasClass('cms-toolbar-item-navigation-disabled')) {
-                        return false;
-                    }
-
-                    that.modal.open({
-                        html: that.ui.pluginsList,
-                        title: that.ui.clipboard.data('title'),
-                        width: MIN_WIDTH,
-                        height: MIN_HEIGHT
-                    });
+            // add remove event
+            that.ui.triggerRemove.on(that.click, function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                if ($(this).parent().hasClass('cms-toolbar-item-navigation-disabled')) {
+                    return false;
+                }
+                that.clear(function () {
+                    // remove element on success
+                    that.modal.close();
+                    that.ui.triggers.parent().addClass('cms-toolbar-item-navigation-disabled');
+                    that.ui.triggerRemove.parent().addClass('cms-toolbar-item-navigation-disabled');
                     that.ui.document.trigger('click.cms.toolbar');
                 });
+            });
+        },
 
-                // add remove event
-                that.ui.triggerRemove.on(that.click, function (e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if ($(this).parent().hasClass('cms-toolbar-item-navigation-disabled')) {
-                        return false;
-                    }
-                    that.clear(function () {
-                        // remove element on success
-                        that.modal.close();
-                        that.ui.triggers.parent().addClass('cms-toolbar-item-navigation-disabled');
-                        that.ui.triggerRemove.parent().addClass('cms-toolbar-item-navigation-disabled');
-                        that.ui.document.trigger('click.cms.toolbar');
-                    });
-                });
-            },
+        /**
+         * Clears the clipboard by quering the server.
+         * Callback is optional, but if provided - it's called
+         * no matter what outcome was of the ajax call.
+         *
+         * @method clear
+         * @param {Function} [callback]
+         */
+        clear: function (callback) {
+            // post needs to be a string, it will be converted using JSON.parse
+            var post = '{ "csrfmiddlewaretoken": "' + CMS.config.csrf + '" }';
+            var pasteItems = $('.cms-submenu-item [data-rel=paste]').parent().
+                addClass('cms-submenu-item-disabled');
+            pasteItems.find('.cms-submenu-item-paste-tooltip').css('display', 'none');
+            pasteItems.find('.cms-submenu-item-paste-tooltip-empty').css('display', 'block');
 
-            /**
-             * Clears the clipboard by quering the server.
-             * Callback is optional, but if provided - it's called
-             * no matter what outcome was of the ajax call.
-             *
-             * @method clear
-             * @param {Function} [callback]
-             */
-            clear: function (callback) {
-                // post needs to be a string, it will be converted using JSON.parse
-                var post = '{ "csrfmiddlewaretoken": "' + CMS.config.csrf + '" }';
-                var pasteItems = $('.cms-submenu-item [data-rel=paste]').parent().
-                    addClass('cms-submenu-item-disabled');
-                pasteItems.find('.cms-submenu-item-paste-tooltip').css('display', 'none');
-                pasteItems.find('.cms-submenu-item-paste-tooltip-empty').css('display', 'block');
-
-                // redirect to ajax
-                CMS.API.Toolbar.openAjax({
-                    url: CMS.config.clipboard.url,
-                    post: post,
-                    callback: callback
-                });
-            }
-
-        });
+            // redirect to ajax
+            CMS.API.Toolbar.openAjax({
+                url: CMS.config.clipboard.url,
+                post: post,
+                callback: callback
+            });
+        }
 
     });
 })(CMS.$);

--- a/cms/tests/frontend/unit/cms.clipboard.test.js
+++ b/cms/tests/frontend/unit/cms.clipboard.test.js
@@ -196,5 +196,57 @@ describe('CMS.Clipboard', function () {
             });
         });
 
+        it('resets plugins "paste" menu item to show correct tooltip', function () {
+            var statesBefore = [
+                {
+                    empty: 'none',
+                    restricted: 'block',
+                    disabled: 'none'
+                },
+                {
+                    empty: 'none',
+                    restricted: 'none',
+                    disabled: 'block'
+                },
+                {
+                    empty: 'block',
+                    restricted: 'none',
+                    disabled: 'none'
+                },
+                {
+                    empty: 'none',
+                    restricted: 'none',
+                    disabled: 'none'
+                }
+            ];
+
+            var stateAfter = {
+                empty: 'block',
+                restricted: 'none',
+                disabled: 'none'
+            };
+
+            statesBefore.forEach(function (obj, index) {
+                var el = $('#submenu-item-' + (index + 1));
+                Object.keys(obj).forEach(function (key) {
+                    var value = obj[key];
+                    expect(el.find('.cms-submenu-item-paste-tooltip-' + key)).toHaveCss({
+                        display: value
+                    });
+                });
+            });
+
+            clipboard.clear();
+
+            statesBefore.forEach(function (obj, index) {
+                var el = $('#submenu-item-' + (index + 1));
+                Object.keys(stateAfter).forEach(function (key) {
+                    var value = stateAfter[key];
+                    expect(el.find('.cms-submenu-item-paste-tooltip-' + key)).toHaveCss({
+                        display: value
+                    });
+                });
+            });
+        });
     });
 });

--- a/cms/tests/frontend/unit/cms.clipboard.test.js
+++ b/cms/tests/frontend/unit/cms.clipboard.test.js
@@ -1,3 +1,4 @@
+/* global document */
 'use strict';
 
 describe('CMS.Clipboard', function () {
@@ -7,14 +8,110 @@ describe('CMS.Clipboard', function () {
         expect(CMS.Clipboard).toBeDefined();
     });
 
-    it('has public API');
+    it('has public API', function () {
+        expect(CMS.Clipboard.prototype.clear).toEqual(jasmine.any(Function));
+    });
 
     describe('instance', function () {
-        it('has options');
-        it('has ui');
-        it('has its own private modal instance');
-        it('sets up events to open the modal');
-        it('sets up events to clear the clipboard');
+        var clipboard;
+        beforeEach(function (done) {
+            fixture.load('clipboard.html');
+            $(function () {
+                clipboard = new CMS.Clipboard();
+                done();
+            });
+        });
+
+        afterEach(function () {
+            fixture.cleanup();
+        });
+
+        it('has no options', function () {
+            expect(clipboard.options).toEqual(undefined);
+        });
+
+        it('has ui', function () {
+            expect(clipboard.ui).toEqual(jasmine.any(Object));
+            expect(Object.keys(clipboard.ui)).toContain('clipboard');
+            expect(Object.keys(clipboard.ui)).toContain('triggers');
+            expect(Object.keys(clipboard.ui)).toContain('triggerRemove');
+            expect(Object.keys(clipboard.ui)).toContain('pluginsList');
+            expect(Object.keys(clipboard.ui)).toContain('document');
+            expect(Object.keys(clipboard.ui).length).toEqual(5);
+        });
+
+        it('has its own private modal instance', function () {
+            expect(clipboard.modal).toEqual(jasmine.any(Object));
+            // there's no reliable way to check if it's really modal,
+            // since Class.js has no instanceof, but this will suffice
+            expect(clipboard.modal.ui.modal).toEqual(jasmine.any(Object));
+        });
+
+        it('sets up events to open the modal (enabled)', function () {
+            expect(clipboard.ui.triggers).toHandle('click.cms.clipboard');
+
+            spyOn(clipboard.modal, 'open');
+            clipboard.ui.triggers.trigger('click.cms.clipboard');
+            expect(clipboard.modal.open).toHaveBeenCalledWith({
+                html: clipboard.ui.pluginsList,
+                title: 'Clipboard',
+                width: 400,
+                height: 117
+            });
+        });
+
+        it('sets up events to open the modal (disabled)', function () {
+            expect(clipboard.ui.triggers).toHandle('click.cms.clipboard');
+            spyOn(clipboard.modal, 'open');
+            clipboard.ui.triggers.parent().addClass('cms-toolbar-item-navigation-disabled');
+            clipboard.ui.triggers.trigger('click.cms.clipboard');
+            expect(clipboard.modal.open).not.toHaveBeenCalled();
+        });
+
+        it('sets up events to open the modal which trigger click on document', function (done) {
+            expect(clipboard.ui.triggers).toHandle('click.cms.clipboard');
+            spyOn(clipboard.modal, 'open');
+            $(document).on('click.cms.toolbar', function () {
+                $(this).off('click.cms.toolbar');
+                done();
+            });
+
+            clipboard.ui.triggers.trigger('click.cms.clipboard');
+        });
+
+
+        it('sets up events to clear the clipboard (enabled)', function () {
+            spyOn(clipboard, 'clear').and.callFake(function (callback) {
+                callback();
+            });
+            spyOn(clipboard.modal, 'close');
+            expect(clipboard.ui.triggerRemove).toHandle('click.cms.clipboard');
+            expect(clipboard.ui.triggers.parent()).not.toHaveClass('cms-toolbar-item-navigation-disabled');
+            expect(clipboard.ui.triggerRemove.parent()).not.toHaveClass('cms-toolbar-item-navigation-disabled');
+            var click = spyOnEvent(clipboard.ui.document, 'click.cms.toolbar');
+
+            clipboard.ui.triggerRemove.trigger('click');
+            expect(clipboard.clear).toHaveBeenCalled();
+            expect(clipboard.modal.close).toHaveBeenCalled();
+            expect(clipboard.ui.triggers.parent()).toHaveClass('cms-toolbar-item-navigation-disabled');
+            expect(clipboard.ui.triggerRemove.parent()).toHaveClass('cms-toolbar-item-navigation-disabled');
+            expect(click).toHaveBeenTriggered();
+        });
+
+        it('sets up events to clear the clipboard (disabled)', function () {
+            spyOn(clipboard, 'clear').and.callFake(function (callback) {
+                callback();
+            });
+            spyOn(clipboard.modal, 'close');
+            var click = spyOnEvent(clipboard.ui.document, 'click.cms.toolbar');
+
+            clipboard.ui.triggerRemove.parent().addClass('cms-toolbar-item-navigation-disabled');
+
+            clipboard.ui.triggerRemove.trigger('click');
+            expect(clipboard.clear).not.toHaveBeenCalled();
+            expect(clipboard.modal.close).not.toHaveBeenCalled();
+            expect(click).not.toHaveBeenTriggered();
+        });
     });
 
     describe('.clear()', function () {

--- a/cms/tests/frontend/unit/cms.clipboard.test.js
+++ b/cms/tests/frontend/unit/cms.clipboard.test.js
@@ -115,6 +115,43 @@ describe('CMS.Clipboard', function () {
     });
 
     describe('.clear()', function () {
-        it('makes a request to the API');
+        var clipboard;
+        beforeEach(function (done) {
+            fixture.load('clipboard.html');
+            CMS.API.Toolbar = {
+                openAjax: jasmine.createSpy()
+            };
+            CMS.config = {
+                csrf: 'test_csrf',
+                clipboard: {
+                    url: 'clear-clipboard'
+                }
+            };
+            $(function () {
+                clipboard = new CMS.Clipboard();
+                done();
+            });
+        });
+
+        afterEach(function () {
+            fixture.cleanup();
+        });
+
+        it('makes a request to the API', function () {
+            clipboard.clear();
+            expect(CMS.API.Toolbar.openAjax).toHaveBeenCalledWith({
+                url: 'clear-clipboard',
+                post: '{ "csrfmiddlewaretoken": "test_csrf" }',
+                callback: undefined
+            });
+
+            clipboard.clear($.noop);
+            expect(CMS.API.Toolbar.openAjax).toHaveBeenCalledWith({
+                url: 'clear-clipboard',
+                post: '{ "csrfmiddlewaretoken": "test_csrf" }',
+                callback: $.noop
+            });
+        });
+
     });
 });

--- a/cms/tests/frontend/unit/cms.clipboard.test.js
+++ b/cms/tests/frontend/unit/cms.clipboard.test.js
@@ -112,6 +112,49 @@ describe('CMS.Clipboard', function () {
             expect(clipboard.modal.close).not.toHaveBeenCalled();
             expect(click).not.toHaveBeenTriggered();
         });
+
+        it('sets up events to clear "add plugin" placeholder', function () {
+            $('<div class="cms-add-plugin-placeholder"></div>').prependTo('body');
+            clipboard.modal.trigger('cms.modal.loaded');
+            expect($('.cms-add-plugin-placeholder')).not.toExist();
+
+            $('<div class="cms-add-plugin-placeholder"></div>').prependTo('body');
+            clipboard.modal.trigger('cms.modal.closed');
+            expect($('.cms-add-plugin-placeholder')).not.toExist();
+        });
+
+        it('sets up events to move pluginList back to the modal', function () {
+            $('<div class="cms-modal"></div>').prependTo(fixture.el);
+            clipboard = new CMS.Clipboard();
+
+            CMS.API.Tooltip = {
+                hide: jasmine.createSpy()
+            };
+
+            clipboard.ui.triggers.trigger('click');
+            expect(clipboard.ui.clipboard).not.toContainElement(clipboard.ui.pluginList);
+
+            // modal is closed
+            clipboard.modal.trigger('cms.modal.closed');
+            expect(clipboard.ui.clipboard).toContainElement(clipboard.ui.pluginsList);
+
+            clipboard.ui.triggers.trigger('click');
+            expect(clipboard.ui.clipboard).not.toContainElement(clipboard.ui.pluginList);
+
+            // this modal instance is being opened again
+            clipboard.modal.trigger('cms.modal.load');
+            expect(clipboard.ui.clipboard).toContainElement(clipboard.ui.pluginsList);
+
+            clipboard.ui.triggers.trigger('click');
+            expect(clipboard.ui.clipboard).not.toContainElement(clipboard.ui.pluginList);
+
+            // new modal instance overtook and is opening
+            clipboard.modal.ui.modal.trigger('cms.modal.load');
+            expect(clipboard.ui.clipboard).toContainElement(clipboard.ui.pluginsList);
+
+            // manually cleaning up, otherwise PhantomJS fails
+            $('.cms-modal').remove();
+        });
     });
 
     describe('.clear()', function () {

--- a/cms/tests/frontend/unit/cms.clipboard.test.js
+++ b/cms/tests/frontend/unit/cms.clipboard.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+describe('CMS.Clipboard', function () {
+    fixture.setBase('cms/tests/frontend/unit/fixtures');
+
+    it('creates a Clipboard class', function () {
+        expect(CMS.Clipboard).toBeDefined();
+    });
+
+    it('has public API');
+
+    describe('instance', function () {
+        it('has options');
+        it('has ui');
+        it('has its own private modal instance');
+        it('sets up events to open the modal');
+        it('sets up events to clear the clipboard');
+    });
+
+    describe('.clear()', function () {
+        it('makes a request to the API');
+    });
+});

--- a/cms/tests/frontend/unit/fixtures/clipboard.html
+++ b/cms/tests/frontend/unit/fixtures/clipboard.html
@@ -1,26 +1,61 @@
-<div class="cms-clipboard" data-title="Clipboard">
-    <div class="cms-plugins">
-        <div class="cms-plugin cms-plugin-3" style="display: none;"></div>
+<div class="cms cms-reset">
+    <div class="cms-clipboard" data-title="Clipboard">
+        <div class="cms-plugins">
+            <div class="cms-plugin cms-plugin-3" style="display: none;"></div>
+        </div>
+
+        <div class="cms-clipboard-containers cms-dragarea cms-draggables">
+            <div class="cms-draggable cms-draggable-3 cms-draggable-from-clipboard">
+                <div class="cms-dragitem cms-dragitem-handler">
+                    <span class="cms-submenu-lang">en</span>
+                    <span class="cms-dragitem-text" title="Bootstrap3AlertCMSPlugin ID: 3"><strong>Alert</strong> </span>
+                </div>
+
+                <div class="cms-collapsable-container cms-hidden cms-draggables">
+                </div>
+            </div>
+        </div>
     </div>
 
-    <div class="cms-clipboard-containers cms-dragarea cms-draggables">
-        <div class="cms-draggable cms-draggable-3 cms-draggable-from-clipboard">
-            <div class="cms-dragitem cms-dragitem-handler">
-                <span class="cms-submenu-lang">en</span>
-                <span class="cms-dragitem-text" title="Bootstrap3AlertCMSPlugin ID: 3"><strong>Alert</strong> </span>
+    <ul>
+        <li class="cms-clipboard-trigger">
+            <a href="#">Open clipboard</a>
+        </li>
+        <li class="cms-clipboard-empty">
+            <a href="#">Empty clipboard</a>
+        </li>
+    </ul>
+
+    <!-- fake submenu "paste" items -->
+    <div class="cms-submenu-dropdown cms-submenu-dropdown-settings">
+        <div class="cms-dropdown-inner">
+            <div id="submenu-item-1" class="cms-submenu-item">
+                <a data-icon="paste" data-rel="paste" href="#">Paste</a>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-empty cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="Clipboard is empty."></span>
+                <span style="display: block" class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-restricted cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="This plugin does not allow plugins of this type as nested plugins."></span>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-disabled cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="This plugin cannot have nested plugins."></span>
             </div>
 
-            <div class="cms-collapsable-container cms-hidden cms-draggables">
+            <div id="submenu-item-2" class="cms-submenu-item">
+                <a data-icon="paste" data-rel="paste" href="#">Paste</a>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-empty cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="Clipboard is empty."></span>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-restricted cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="This plugin does not allow plugins of this type as nested plugins."></span>
+                <span style="display: block" class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-disabled cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="This plugin cannot have nested plugins."></span>
+            </div>
+
+            <div id="submenu-item-3" class="cms-submenu-item">
+                <a data-icon="paste" data-rel="paste" href="#">Paste</a>
+                <span style="display: block" class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-empty cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="Clipboard is empty."></span>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-restricted cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="This plugin does not allow plugins of this type as nested plugins."></span>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-disabled cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="This plugin cannot have nested plugins."></span>
+            </div>
+
+            <div id="submenu-item-4" class="cms-submenu-item">
+                <a data-icon="paste" data-rel="paste" href="#">Paste</a>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-empty cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="Clipboard is empty."></span>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-restricted cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="This plugin does not allow plugins of this type as nested plugins."></span>
+                <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-disabled cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-tooltip="This plugin cannot have nested plugins."></span>
             </div>
         </div>
     </div>
 </div>
-
-<ul>
-    <li class="cms-clipboard-trigger">
-        <a href="#">Open clipboard</a>
-    </li>
-    <li class="cms-clipboard-empty">
-        <a href="#">Empty clipboard</a>
-    </li>
-</ul>

--- a/cms/tests/frontend/unit/fixtures/clipboard.html
+++ b/cms/tests/frontend/unit/fixtures/clipboard.html
@@ -15,3 +15,12 @@
         </div>
     </div>
 </div>
+
+<ul>
+    <li class="cms-clipboard-trigger">
+        <a href="#">Open clipboard</a>
+    </li>
+    <li class="cms-clipboard-empty">
+        <a href="#">Empty clipboard</a>
+    </li>
+</ul>


### PR DESCRIPTION
* add tests for cms.clipboard
* remove the need to wait for dom ready to declare class instance

as usual better to review with https://github.com/FinalAngel/django-cms/pull/114/files?w=1 because changes in cms.clipboard.js are mostly indentation