### PR TITLE
Feature/make integration tests independent

### DIFF
--- a/cms/tests/frontend/integration/addFirstPage.js
+++ b/cms/tests/frontend/integration/addFirstPage.js
@@ -6,6 +6,11 @@
 var globals = require('./settings/globals');
 var content = require('./settings/globals').content.page;
 var messages = require('./settings/messages').page.creation;
+var cms = require('./helpers/cms');
+
+casper.test.setUp(function (done) {
+    casper.start().then(cms.login).run(done);
+});
 
 casper.test.begin('Add First Page', function (test) {
     casper
@@ -48,4 +53,11 @@ casper.test.begin('Add First Page', function (test) {
             this.removeAllFilters('page.confirm');
             test.done();
         });
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.logout)
+        .run(done);
 });

--- a/cms/tests/frontend/integration/addFirstPage.js
+++ b/cms/tests/frontend/integration/addFirstPage.js
@@ -9,13 +9,15 @@ var messages = require('./settings/messages').page.creation;
 var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
-    casper.start().then(cms.login).run(done);
+    casper.start()
+        .then(cms.login())
+        .run(done);
 });
 
 casper.test.tearDown(function (done) {
     casper.start()
         .then(cms.removePage())
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/addFirstPage.js
+++ b/cms/tests/frontend/integration/addFirstPage.js
@@ -6,10 +6,17 @@
 var globals = require('./settings/globals');
 var content = require('./settings/globals').content.page;
 var messages = require('./settings/messages').page.creation;
-var cms = require('./helpers/cms');
+var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
     casper.start().then(cms.login).run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.logout)
+        .run(done);
 });
 
 casper.test.begin('Add First Page', function (test) {
@@ -53,11 +60,4 @@ casper.test.begin('Add First Page', function (test) {
             this.removeAllFilters('page.confirm');
             test.done();
         });
-});
-
-casper.test.tearDown(function (done) {
-    casper.start()
-        .then(cms.removeFirstPage)
-        .then(cms.logout)
-        .run(done);
 });

--- a/cms/tests/frontend/integration/addFirstPage.js
+++ b/cms/tests/frontend/integration/addFirstPage.js
@@ -14,7 +14,7 @@ casper.test.setUp(function (done) {
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.removeFirstPage)
+        .then(cms.removePage())
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/addFirstPage.js
+++ b/cms/tests/frontend/integration/addFirstPage.js
@@ -32,7 +32,7 @@ casper.test.begin('Add First Page', function (test) {
             }, true);
         })
         .waitForSelector('.cms-ready', function () {
-            test.assertSelectorHasText('.cms-plugin-1', content.text, messages.created);
+            test.assertSelectorHasText('.cms-plugin', content.text, messages.created);
 
             // handles confirm popup
             this.setFilter('page.confirm', function () {

--- a/cms/tests/frontend/integration/createContent.js
+++ b/cms/tests/frontend/integration/createContent.js
@@ -68,18 +68,24 @@ casper.test.begin('User Add Content', function (test) {
                 this.sendKeys('.cms-quicksearch input', 'text', { reset: true });
             });
             this.waitUntilVisible('.cms-plugin-picker .cms-submenu-item [data-rel="add"]', function () {
-                test.assertVisible('.cms-plugin-picker .cms-submenu-item [data-rel="add"]',
-                    messages.filteredPluginAvailable);
+                this.waitFor(function () {
+                    return this.evaluate(function () {
+                        return $('.cms-submenu-item [data-rel="add"]:visible').length === 1;
+                    });
+                }).then(function () {
+                    test.assertVisible('.cms-plugin-picker .cms-submenu-item [data-rel="add"]',
+                        messages.filteredPluginAvailable);
+                });
             });
             this.then(function () {
-                this.click('.cms-plugin-picker .cms-submenu-item [data-rel="add"]');
+                this.click(xPath('//a[@data-rel="add"]/text()[normalize-space(.)="Text"]'));
             });
             // ensure previous content has been changed
             this.waitWhileVisible('.cms-plugin-picker .cms-submenu-item [data-rel="add"]');
         })
         .withFrame(0, function () {
             casper
-                .waitUntilVisible('#text_form', function () {
+                .waitUntilVisible('.cke_inner', function () {
                     // explicitly put text to ckeditor
                     this.evaluate(function (contentData) {
                         CMS.CKEditor.editor.setData(contentData);

--- a/cms/tests/frontend/integration/createContent.js
+++ b/cms/tests/frontend/integration/createContent.js
@@ -14,7 +14,7 @@ var randomText = randomString({ length: 50, withWhitespaces: false });
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
@@ -22,7 +22,7 @@ casper.test.setUp(function (done) {
 casper.test.tearDown(function (done) {
     casper.start()
         .then(cms.removePage())
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/createContent.js
+++ b/cms/tests/frontend/integration/createContent.js
@@ -21,7 +21,7 @@ casper.test.setUp(function (done) {
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.removeFirstPage)
+        .then(cms.removePage())
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/createContent.js
+++ b/cms/tests/frontend/integration/createContent.js
@@ -6,9 +6,25 @@
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.addContent;
 var randomString = require('./helpers/randomString').randomString;
+var cms = require('./helpers/cms')();
+var xPath = require('casper').selectXPath;
 
 // random text string for filtering and content purposes
 var randomText = randomString({ length: 50, withWhitespaces: false });
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .then(cms.addPage({ name: 'First page' }))
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.logout)
+        .run(done);
+});
 
 casper.test.begin('User Add Content', function (test) {
     casper
@@ -24,6 +40,7 @@ casper.test.begin('User Add Content', function (test) {
         .waitUntilVisible('.cms-plugin-picker .cms-submenu-item [data-rel="add"]', function () {
             this.click('.cms-plugin-picker .cms-submenu-item [data-rel="add"]');
         })
+        .waitWhileVisible('.cms-modal-morphing')
         .waitUntilVisible('.cms-modal-open', function () {
             this.setFilter('page.confirm', function () {
                 return true;

--- a/cms/tests/frontend/integration/createContent.js
+++ b/cms/tests/frontend/integration/createContent.js
@@ -15,7 +15,7 @@ var randomText = randomString({ length: 50, withWhitespaces: false });
 casper.test.setUp(function (done) {
     casper.start()
         .then(cms.login)
-        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/editContent.js
+++ b/cms/tests/frontend/integration/editContent.js
@@ -14,7 +14,7 @@ var xPath = casperjs.selectXPath;
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .then(cms.addPage({ title: 'First page' }))
         .then(cms.addPlugin({
             type: 'TextPlugin',
@@ -28,7 +28,7 @@ casper.test.setUp(function (done) {
 casper.test.tearDown(function (done) {
     casper.start()
         .then(cms.removePage())
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/editContent.js
+++ b/cms/tests/frontend/integration/editContent.js
@@ -15,7 +15,7 @@ var xPath = casperjs.selectXPath;
 casper.test.setUp(function (done) {
     casper.start()
         .then(cms.login)
-        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.addPage({ title: 'First page' }))
         .then(cms.addPlugin({
             type: 'TextPlugin',
             content: {

--- a/cms/tests/frontend/integration/editContent.js
+++ b/cms/tests/frontend/integration/editContent.js
@@ -8,6 +8,29 @@ var messages = require('./settings/messages').page.editContent;
 var randomString = require('./helpers/randomString').randomString;
 // random text string for filtering and content purposes
 var randomText = randomString({ length: 50, withWhitespaces: false });
+var casperjs = require('casper');
+var cms = require('./helpers/cms')(casperjs);
+var xPath = casperjs.selectXPath;
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.addPlugin({
+            type: 'TextPlugin',
+            content: {
+                id_body: 'Random text'
+            }
+        }))
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.logout)
+        .run(done);
+});
 
 
 casper.test.begin('Edit content', function (test) {
@@ -15,11 +38,17 @@ casper.test.begin('Edit content', function (test) {
 
     casper
         .start(globals.editUrl)
-
+        // make sure we are in content mode
+        .waitUntilVisible('.cms-toolbar-expanded', function () {
+            this.click('.cms-toolbar-item-cms-mode-switcher .cms-btn[href="?edit"]');
+        })
         // check edit modal window appearance after double click in content mode
         // double click on last added plugin content
         .waitUntilVisible('.cms-toolbar-expanded', function () {
-            this.mouse.doubleclick('.cms-plugin:last-child');
+            this.mouse.doubleclick(
+                // pick a div with class cms-plugin that has a p that has text "Random text"
+                xPath('//div[contains(@class, "cms-plugin ")][.//p[text()[contains(.,"Random text")]]][last()]')
+            );
         })
         .waitUntilVisible('.cms-modal-open')
         // change content inside appeared modal window

--- a/cms/tests/frontend/integration/editContent.js
+++ b/cms/tests/frontend/integration/editContent.js
@@ -27,7 +27,7 @@ casper.test.setUp(function (done) {
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.removeFirstPage)
+        .then(cms.removePage())
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/editMode.js
+++ b/cms/tests/frontend/integration/editMode.js
@@ -18,7 +18,7 @@ casper.test.setUp(function (done) {
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.removeFirstPage)
+        .then(cms.removePage())
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/editMode.js
+++ b/cms/tests/frontend/integration/editMode.js
@@ -5,6 +5,17 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.editMode;
+var content = require('./settings/globals').content.page;
+
+var cms = require('./helpers/cms');
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .then(cms.addPage({ name: content.title }))
+        .run(done);
+});
+
 
 casper.test.begin('Opening Page in Edit Mode', function (test) {
     casper

--- a/cms/tests/frontend/integration/editMode.js
+++ b/cms/tests/frontend/integration/editMode.js
@@ -11,7 +11,7 @@ var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .then(cms.addPage({ title: content.title }))
         .run(done);
 });
@@ -19,7 +19,7 @@ casper.test.setUp(function (done) {
 casper.test.tearDown(function (done) {
     casper.start()
         .then(cms.removePage())
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/editMode.js
+++ b/cms/tests/frontend/integration/editMode.js
@@ -7,7 +7,7 @@ var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.editMode;
 var content = require('./settings/globals').content.page;
 
-var cms = require('./helpers/cms');
+var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
     casper.start()
@@ -16,6 +16,12 @@ casper.test.setUp(function (done) {
         .run(done);
 });
 
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.logout)
+        .run(done);
+});
 
 casper.test.begin('Opening Page in Edit Mode', function (test) {
     casper

--- a/cms/tests/frontend/integration/editMode.js
+++ b/cms/tests/frontend/integration/editMode.js
@@ -12,7 +12,7 @@ var cms = require('./helpers/cms')();
 casper.test.setUp(function (done) {
     casper.start()
         .then(cms.login)
-        .then(cms.addPage({ name: content.title }))
+        .then(cms.addPage({ title: content.title }))
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/handlers/suiteFailures.js
+++ b/cms/tests/frontend/integration/handlers/suiteFailures.js
@@ -6,11 +6,17 @@
 module.exports = {
     bind: function () {
         casper.on('step.error', function (error) {
-            casper.die('assert failed: ' +  error.result.standard);
+            casper.die('assert failed: ' +  error.message);
         });
 
         casper.on('waitFor.timeout', function (timeout, error) {
-            casper.die('waitFor failed, couldn\'t find ' + error.selector + ' within ' + timeout + 'ms');
+            if (error.selector) {
+                casper.die('waitFor failed, couldn\'t find ' + error.selector + ' within ' + timeout + 'ms');
+            } else if (error.visible) {
+                casper.die('waitFor failed, couldn\'t find ' + error.visible + ' within ' + timeout + 'ms');
+            } else {
+                casper.die('waitFor failed with error', JSON.stringify(error, null, 4));
+            }
         });
     }
 };

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -1,45 +1,104 @@
 'use strict';
 var globals = require('../settings/globals');
 
-module.exports = {
-    login: function () {
-        return this.thenOpen(globals.adminUrl).then(function () {
-            this.fill('#login-form', globals.credentials, true);
-        });
-    },
-
-    logout: function () {
-        return this.thenOpen(globals.adminLogoutUrl);
-    },
-
-    removeFirstPage: function () {
-        return this.thenOpen(globals.adminPagesUrl)
-            .waitUntilVisible('.tree .deletelink')
-            .then(function () {
-                this.click('.tree .deletelink');
-            })
-            .waitUntilVisible('input[type=submit]')
-            .then(function () {
-                this.click('input[type=submit]');
+module.exports = function (casperjs) {
+    return {
+        login: function () {
+            return this.thenOpen(globals.adminUrl).then(function () {
+                this.fill('#login-form', globals.credentials, true);
             });
-    },
+        },
 
-    /**
-     * Adds the page
-     *
-     * @public
-     * @param {Object} opts
-     * @param {String} opts.name name of the page
-     */
-    addPage: function (opts) {
-        return function () {
-            return this.thenOpen(globals.adminPagesUrl + 'add/')
-                .waitUntilVisible('#id_title')
+        logout: function () {
+            return this.thenOpen(globals.adminLogoutUrl);
+        },
+
+        removeFirstPage: function () {
+            return this.thenOpen(globals.adminPagesUrl)
+                .waitUntilVisible('.tree .deletelink')
                 .then(function () {
-                    this.sendKeys('#id_title', opts.name);
-                    this.captureSelector('test.png', 'html');
-                    this.click('input[name="_save"]');
+                    this.click('.tree .deletelink');
+                })
+                .waitUntilVisible('input[type=submit]')
+                .then(function () {
+                    this.click('input[type=submit]');
                 });
-        };
-    }
+        },
+
+        /**
+        * Adds the page
+        *
+        * @public
+        * @param {Object} opts
+        * @param {String} opts.name name of the page
+        */
+        addPage: function (opts) {
+            return function () {
+                return this.thenOpen(globals.adminPagesUrl + 'add/')
+                    .waitUntilVisible('#id_title')
+                    .then(function () {
+                        this.sendKeys('#id_title', opts.name);
+                        this.click('input[name="_save"]');
+                    });
+            };
+        },
+
+        /**
+         * Adds the plugin (currently to the first placeholder)
+         *
+         * @param {Object} opts
+         * @param {String} opts.type type of the plugin to add
+         * @param {Object} opts.content object containing fields and values
+         * @example
+         *
+         *     cms.addPlugin({
+         *         type: 'TextPlugin',
+         *         content: {
+         *             id_body: 'Some text'
+         *         }
+         *     });
+         */
+        addPlugin: function (opts) {
+            var xPath = casperjs.selectXPath;
+
+            return function () {
+                return this.thenOpen(globals.editUrl)
+                    .waitUntilVisible('.cms-toolbar-expanded', function () {
+                        this.click('.cms-toolbar-item-cms-mode-switcher .cms-btn[href="?build"]');
+                    })
+                    .waitUntilVisible('.cms-structure', function () {
+                        this.click('.cms-submenu-add [data-tooltip="Add plugin"]');
+                    })
+                    .waitUntilVisible('.cms-plugin-picker .cms-submenu-item [data-rel="add"]', function () {
+                        this.then(function () {
+                            this.click(xPath('//a[@href="' + opts.type + '"]'));
+                        });
+                        // ensure previous content has been changed
+                        this.waitWhileVisible('.cms-plugin-picker .cms-submenu-item [data-rel="add"]');
+                    })
+                    .thenEvaluate(function (opts) {
+                        if (!opts.content) {
+                            return;
+                        }
+                        Object.keys(opts.content).forEach(function (key) {
+                            $('#' + key).val(opts.content[key]);
+                        });
+                    }, opts)
+                    .then(function () {
+                        if (opts.type === 'TextPlugin') {
+                            this.withFrame(0, function () {
+                                casper.waitUntilVisible('.cke_inner', function () {
+                                    // explicitly put text to ckeditor
+                                    this.evaluate(function (contentData) {
+                                        CMS.CKEditor.editor.setData(contentData);
+                                    }, opts.content.id_body);
+                                });
+                            });
+                        }
+                    }).then(function () {
+                        this.click('.cms-modal-buttons .cms-btn-action.default');
+                    });
+            };
+        }
+    };
 };

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -1,0 +1,45 @@
+'use strict';
+var globals = require('../settings/globals');
+
+module.exports = {
+    login: function () {
+        return this.thenOpen(globals.adminUrl).then(function () {
+            this.fill('#login-form', globals.credentials, true);
+        });
+    },
+
+    logout: function () {
+        return this.thenOpen(globals.adminLogoutUrl);
+    },
+
+    removeFirstPage: function () {
+        return this.thenOpen(globals.adminPagesUrl)
+            .waitUntilVisible('.tree .deletelink')
+            .then(function () {
+                this.click('.tree .deletelink');
+            })
+            .waitUntilVisible('input[type=submit]')
+            .then(function () {
+                this.click('input[type=submit]');
+            });
+    },
+
+    /**
+     * Adds the page
+     *
+     * @public
+     * @param {Object} opts
+     * @param {String} opts.name name of the page
+     */
+    addPage: function (opts) {
+        return function () {
+            return this.thenOpen(globals.adminPagesUrl + 'add/')
+                .waitUntilVisible('#id_title')
+                .then(function () {
+                    this.sendKeys('#id_title', opts.name);
+                    this.captureSelector('test.png', 'html');
+                    this.click('input[name="_save"]');
+                });
+        };
+    }
+};

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -56,14 +56,14 @@ module.exports = function (casperjs) {
         *
         * @public
         * @param {Object} opts
-        * @param {String} opts.name name of the page
+        * @param {String} opts.title name of the page
         */
         addPage: function (opts) {
             return function () {
                 return this.thenOpen(globals.adminPagesUrl + 'add/')
                     .waitUntilVisible('#id_title')
                     .then(function () {
-                        this.sendKeys('#id_title', opts.name);
+                        this.sendKeys('#id_title', opts.title);
                         this.click('input[name="_save"]');
                     });
             };

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -4,13 +4,17 @@ var globals = require('../settings/globals');
 module.exports = function (casperjs) {
     return {
         login: function () {
-            return this.thenOpen(globals.adminUrl).then(function () {
-                this.fill('#login-form', globals.credentials, true);
-            });
+            return function () {
+                return this.thenOpen(globals.adminUrl).then(function () {
+                    this.fill('#login-form', globals.credentials, true);
+                });
+            };
         },
 
         logout: function () {
-            return this.thenOpen(globals.adminLogoutUrl);
+            return function () {
+                return this.thenOpen(globals.adminLogoutUrl);
+            };
         },
 
         /**

--- a/cms/tests/frontend/integration/loginAdmin.js
+++ b/cms/tests/frontend/integration/loginAdmin.js
@@ -6,6 +6,7 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').login.admin;
+var cms = require('./helpers/cms');
 
 casper.test.begin('User Login (via Admin Panel)', function (test) {
     casper
@@ -41,4 +42,8 @@ casper.test.begin('User Login (via Admin Panel)', function (test) {
         .run(function () {
             test.done();
         });
+});
+
+casper.test.tearDown(function (done) {
+    casper.start().then(cms.logout).run(done);
 });

--- a/cms/tests/frontend/integration/loginAdmin.js
+++ b/cms/tests/frontend/integration/loginAdmin.js
@@ -9,7 +9,9 @@ var messages = require('./settings/messages').login.admin;
 var cms = require('./helpers/cms')();
 
 casper.test.tearDown(function (done) {
-    casper.start().then(cms.logout).run(done);
+    casper.start()
+        .then(cms.logout())
+        .run(done);
 });
 
 casper.test.begin('User Login (via Admin Panel)', function (test) {

--- a/cms/tests/frontend/integration/loginAdmin.js
+++ b/cms/tests/frontend/integration/loginAdmin.js
@@ -2,18 +2,6 @@
 'use strict';
 
 // #############################################################################
-// Init all settings and event handlers on suite start
-
-require('./../casperjs.conf').init();
-
-require('./handlers/pageErrors').bind();
-require('./handlers/loadFailures').bind();
-require('./handlers/missingPages').bind();
-require('./handlers/externalMissing').bind();
-require('./handlers/suiteFailures').bind();
-
-
-// #############################################################################
 // User login via the admin panel
 
 var globals = require('./settings/globals');

--- a/cms/tests/frontend/integration/loginAdmin.js
+++ b/cms/tests/frontend/integration/loginAdmin.js
@@ -6,7 +6,7 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').login.admin;
-var cms = require('./helpers/cms');
+var cms = require('./helpers/cms')();
 
 casper.test.tearDown(function (done) {
     casper.start().then(cms.logout).run(done);

--- a/cms/tests/frontend/integration/loginAdmin.js
+++ b/cms/tests/frontend/integration/loginAdmin.js
@@ -8,6 +8,10 @@ var globals = require('./settings/globals');
 var messages = require('./settings/messages').login.admin;
 var cms = require('./helpers/cms');
 
+casper.test.tearDown(function (done) {
+    casper.start().then(cms.logout).run(done);
+});
+
 casper.test.begin('User Login (via Admin Panel)', function (test) {
     casper
         .start(globals.adminUrl, function () {
@@ -42,8 +46,4 @@ casper.test.begin('User Login (via Admin Panel)', function (test) {
         .run(function () {
             test.done();
         });
-});
-
-casper.test.tearDown(function (done) {
-    casper.start().then(cms.logout).run(done);
 });

--- a/cms/tests/frontend/integration/loginToolbar.js
+++ b/cms/tests/frontend/integration/loginToolbar.js
@@ -5,6 +5,22 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').login.toolbar;
+var cms = require('./helpers/cms')();
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.logout)
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.logout)
+        .run(done);
+});
 
 casper.test.begin('User Login (via Toolbar)', function (test) {
     casper

--- a/cms/tests/frontend/integration/loginToolbar.js
+++ b/cms/tests/frontend/integration/loginToolbar.js
@@ -9,16 +9,16 @@ var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .then(cms.addPage({ title: 'First page' }))
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 
 casper.test.tearDown(function (done) {
     casper.start()
         .then(cms.removePage())
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/loginToolbar.js
+++ b/cms/tests/frontend/integration/loginToolbar.js
@@ -17,7 +17,7 @@ casper.test.setUp(function (done) {
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.removeFirstPage)
+        .then(cms.removePage())
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/loginToolbar.js
+++ b/cms/tests/frontend/integration/loginToolbar.js
@@ -10,7 +10,7 @@ var cms = require('./helpers/cms')();
 casper.test.setUp(function (done) {
     casper.start()
         .then(cms.login)
-        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.addPage({ title: 'First page' }))
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/logout.js
+++ b/cms/tests/frontend/integration/logout.js
@@ -9,7 +9,7 @@ var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });

--- a/cms/tests/frontend/integration/logout.js
+++ b/cms/tests/frontend/integration/logout.js
@@ -10,7 +10,7 @@ var cms = require('./helpers/cms')();
 casper.test.setUp(function (done) {
     casper.start()
         .then(cms.login)
-        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/logout.js
+++ b/cms/tests/frontend/integration/logout.js
@@ -5,6 +5,17 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').logout;
+var cms = require('./helpers/cms')();
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .then(cms.addPage({ name: 'First page' }))
+        .run(done);
+});
+
+casper.test.tearDown(function () {
+});
 
 casper.test.begin('User Logout', function (test) {
     casper

--- a/cms/tests/frontend/integration/newPage.js
+++ b/cms/tests/frontend/integration/newPage.js
@@ -6,8 +6,24 @@
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.creation.toolbar;
 var randomString = require('./helpers/randomString').randomString;
+var cms = require('./helpers/cms')();
 
 var newPageTitle = randomString({ length: 50, withWhitespaces: false });
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .then(cms.addPage({ name: 'First page' }))
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.removeFirstPage) // removing both pages
+        .then(cms.logout)
+        .run(done);
+});
 
 casper.test.begin('New Page Creation', function (test) {
     casper

--- a/cms/tests/frontend/integration/newPage.js
+++ b/cms/tests/frontend/integration/newPage.js
@@ -12,7 +12,7 @@ var newPageTitle = randomString({ length: 50, withWhitespaces: false });
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
@@ -21,7 +21,7 @@ casper.test.tearDown(function (done) {
     casper.start()
         .then(cms.removePage({ title: newPageTitle }))
         .then(cms.removePage({ title: 'First page' })) // removing both pages
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/newPage.js
+++ b/cms/tests/frontend/integration/newPage.js
@@ -19,8 +19,8 @@ casper.test.setUp(function (done) {
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.removeFirstPage)
-        .then(cms.removeFirstPage) // removing both pages
+        .then(cms.removePage({ title: newPageTitle }))
+        .then(cms.removePage({ title: 'First page' })) // removing both pages
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/newPage.js
+++ b/cms/tests/frontend/integration/newPage.js
@@ -38,7 +38,7 @@ casper.test.begin('New Page Creation', function (test) {
                 });
         })
         .waitForSelector('.cms-ready', function () {
-            test.assertTitle(newPageTitle, messages.addOk);
+            test.assertTitleMatch(new RegExp(newPageTitle), messages.addOk);
         })
         .run(function () {
             test.done();

--- a/cms/tests/frontend/integration/newPage.js
+++ b/cms/tests/frontend/integration/newPage.js
@@ -13,7 +13,7 @@ var newPageTitle = randomString({ length: 50, withWhitespaces: false });
 casper.test.setUp(function (done) {
     casper.start()
         .then(cms.login)
-        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/settings/globals.js
+++ b/cms/tests/frontend/integration/settings/globals.js
@@ -13,6 +13,8 @@ module.exports = {
     editUrl: 'http://localhost:8000/en/?edit',
     editOffUrl: 'http://localhost:8000/en/?edit_off',
     adminUrl: 'http://localhost:8000/en/admin/login/',
+    adminLogoutUrl: 'http://localhost:8000/en/admin/logout/',
+    adminPagesUrl: 'http://localhost:8000/en/admin/cms/page/',
     credentials: {
         username: 'admin',
         password: 'admin'

--- a/cms/tests/frontend/integration/setup.js
+++ b/cms/tests/frontend/integration/setup.js
@@ -1,0 +1,12 @@
+// #############################################################################
+// Init all settings and event handlers on suite start
+
+require('./../casperjs.conf').init();
+
+require('./handlers/pageErrors').bind();
+require('./handlers/loadFailures').bind();
+require('./handlers/missingPages').bind();
+require('./handlers/externalMissing').bind();
+require('./handlers/suiteFailures').bind();
+
+casper.test.done();

--- a/cms/tests/frontend/integration/sideframe.js
+++ b/cms/tests/frontend/integration/sideframe.js
@@ -5,6 +5,19 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').sideframe;
+var cms = require('./helpers/cms')();
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.logout)
+        .run(done);
+});
 
 casper.test.begin('Sideframe', function (test) {
     casper

--- a/cms/tests/frontend/integration/sideframe.js
+++ b/cms/tests/frontend/integration/sideframe.js
@@ -9,13 +9,13 @@ var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .run(done);
 });
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/switchLanguage.js
+++ b/cms/tests/frontend/integration/switchLanguage.js
@@ -15,7 +15,7 @@ var noPreviewText = 'This page has no preview';
 casper.test.setUp(function (done) {
     casper.start()
         .then(cms.login)
-        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/switchLanguage.js
+++ b/cms/tests/frontend/integration/switchLanguage.js
@@ -21,7 +21,7 @@ casper.test.setUp(function (done) {
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.removeFirstPage)
+        .then(cms.removePage())
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/switchLanguage.js
+++ b/cms/tests/frontend/integration/switchLanguage.js
@@ -6,11 +6,25 @@
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').page.switchLanguage;
 var randomString = require('./helpers/randomString').randomString;
+var cms = require('./helpers/cms')();
 // random text string for filtering and content purposes
 var randomText = randomString({ length: 50, withWhitespaces: false });
 // No Preview Template text
 var noPreviewText = 'This page has no preview';
 
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .then(cms.addPage({ name: 'First page' }))
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.logout)
+        .run(done);
+});
 
 casper.test.begin('Switch language', function (test) {
     casper

--- a/cms/tests/frontend/integration/switchLanguage.js
+++ b/cms/tests/frontend/integration/switchLanguage.js
@@ -14,7 +14,7 @@ var noPreviewText = 'This page has no preview';
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
@@ -22,7 +22,7 @@ casper.test.setUp(function (done) {
 casper.test.tearDown(function (done) {
     casper.start()
         .then(cms.removePage())
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/toolbar.js
+++ b/cms/tests/frontend/integration/toolbar.js
@@ -8,12 +8,14 @@ var messages = require('./settings/messages').toolbar;
 var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
-    casper.start().then(cms.login).run(done);
+    casper.start()
+        .then(cms.login())
+        .run(done);
 });
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/toolbar.js
+++ b/cms/tests/frontend/integration/toolbar.js
@@ -5,6 +5,17 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').toolbar;
+var cms = require('./helpers/cms');
+
+casper.test.setUp(function (done) {
+    casper.start().then(cms.login).run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.logout)
+        .run(done);
+});
 
 casper.test.begin('Toolbar Visibility', function (test) {
     var toolbarOffset = 0;

--- a/cms/tests/frontend/integration/toolbar.js
+++ b/cms/tests/frontend/integration/toolbar.js
@@ -5,7 +5,7 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').toolbar;
-var cms = require('./helpers/cms');
+var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
     casper.start().then(cms.login).run(done);

--- a/cms/tests/frontend/integration/users.js
+++ b/cms/tests/frontend/integration/users.js
@@ -10,7 +10,7 @@ var cms = require('./helpers/cms')();
 casper.test.setUp(function (done) {
     casper.start()
         .then(cms.login)
-        .then(cms.addPage({ name: 'First page' }))
+        .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/users.js
+++ b/cms/tests/frontend/integration/users.js
@@ -16,7 +16,7 @@ casper.test.setUp(function (done) {
 
 casper.test.tearDown(function (done) {
     casper.start()
-        .then(cms.removeFirstPage)
+        .then(cms.removePage())
         .then(cms.logout)
         .run(done);
 });

--- a/cms/tests/frontend/integration/users.js
+++ b/cms/tests/frontend/integration/users.js
@@ -9,7 +9,7 @@ var cms = require('./helpers/cms')();
 
 casper.test.setUp(function (done) {
     casper.start()
-        .then(cms.login)
+        .then(cms.login())
         .then(cms.addPage({ title: 'First page' }))
         .run(done);
 });
@@ -17,7 +17,7 @@ casper.test.setUp(function (done) {
 casper.test.tearDown(function (done) {
     casper.start()
         .then(cms.removePage())
-        .then(cms.logout)
+        .then(cms.logout())
         .run(done);
 });
 

--- a/cms/tests/frontend/integration/users.js
+++ b/cms/tests/frontend/integration/users.js
@@ -5,6 +5,21 @@
 
 var globals = require('./settings/globals');
 var messages = require('./settings/messages').users;
+var cms = require('./helpers/cms')();
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login)
+        .then(cms.addPage({ name: 'First page' }))
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.removeFirstPage)
+        .then(cms.logout)
+        .run(done);
+});
 
 casper.test.begin('Users Management', function (test) {
     casper

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,13 +188,14 @@ gulp.task('tests:integration', function (done) {
         'logout',
         'loginToolbar'
     ];
+    var pre = ['setup'];
 
     if (argv && argv.tests) {
         files = argv.tests.split(',');
         gutil.log('Running tests for ' + files.join(', '));
     }
 
-    var tests = files.map(function (file) {
+    var tests = pre.concat(files).map(function (file) {
         return PROJECT_PATH.tests + '/integration/' + file + '.js';
     });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -199,7 +199,7 @@ gulp.task('tests:integration', function (done) {
         return PROJECT_PATH.tests + '/integration/' + file + '.js';
     });
 
-    var casperChild = spawn('./node_modules/.bin/casperjs', ['test'].concat(tests));
+    var casperChild = spawn('./node_modules/.bin/casperjs', ['test', '--web-security=no'].concat(tests));
 
     casperChild.stdout.on('data', function (data) {
         gutil.log('CasperJS:', data.toString().slice(0, -1));


### PR DESCRIPTION
- Added `cms` helpers to quickly login/logout/add/remove page/addplugin
- added setup / teardown for every test, so they can be run separately
- changed some tests because they were a bit too strict