### PR TITLE
Fix issues with move, copy and paste

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -842,31 +842,93 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
     @transaction.atomic
     def move_page(self, request, page_id, extra_context=None):
         """
-        Move the page to the requested target, at the given position
+        Move the page to the requested target, at the given position.
+
+        NOTE: We have to change from one "coordinate system" to another to
+        adapt JSTree to Django Treebeard.
+
+        If the Tree looks like this:
+
+            <root>
+               ⊢ …
+               ⊢ …
+               ⊢ Page 4
+                   ⊢ Page 5 (position 0)
+                   ⊢ …
+
+        For example,
+            target=4, position=1 => target=5, position="right"
+            target=4, position=0 => target=4, position="first-child"
+
         """
         target = request.POST.get('target', None)
-        position = request.POST.get('position', None)
-        if target is None or position is None:
-            return HttpResponseRedirect('../../')
+        position = request.POST.get('position', 0)
+        site_id = request.POST.get('site', None)
+
+        try:
+            position = int(position)
+        except (TypeError, ValueError):
+            position = 0
 
         try:
             page = self.model.objects.get(pk=page_id)
-            target = self.model.objects.get(pk=target)
         except self.model.DoesNotExist:
             return jsonify_request(HttpResponseBadRequest("error"))
 
-        # does he haves permissions to do this...?
-        if not page.has_move_page_permission(request) or \
-                not target.has_add_permission(request):
+        try:
+            site = Site.objects.get(id=int(site_id))
+        except (TypeError, ValueError, MultipleObjectsReturned,
+                ObjectDoesNotExist):
+            site = get_current_site(request)
+
+        if target is None:
+            # Special case: If «target» is not provided, it means to let the
+            # page become a new root node.
+            try:
+                tb_target = Page.get_root_nodes().filter(
+                    publisher_is_draft=True, site=site)[position]
+                if page.is_sibling_of(tb_target) and page.path < tb_target.path:
+                    tb_position = "right"
+                else:
+                    tb_position = "left"
+            except IndexError:
+                # Move page to become the last root node.
+                tb_target = Page.get_last_root_node()
+                tb_position = "right"
+        else:
+            try:
+                target = tb_target = self.model.objects.get(pk=int(target), site=site)
+            except (TypeError, ValueError, self.model.DoesNotExist):
+                return jsonify_request(HttpResponseBadRequest("error"))
+            if position == 0:
+                tb_position = "first-child"
+            else:
+                try:
+                    tb_target = target.get_children().filter(
+                        publisher_is_draft=True, site=site)[position]
+                    if page.is_sibling_of(tb_target) and page.path < tb_target.path:
+                        tb_position = "right"
+                    else:
+                        tb_position = "left"
+                except IndexError:
+                    tb_position = "last-child"
+
+        # Does the user have permissions to do this...?
+        if not page.has_move_page_permission(request) or (
+                    target and not target.has_add_permission(request)):
             return jsonify_request(
-                HttpResponseForbidden(force_text(_("Error! You don't have permissions to move this page. Please reload the page"))))
-            # move page
-        page.move_page(target, position)
+                HttpResponseForbidden(
+                    force_text(_("Error! You don't have permissions to move "
+                                 "this page. Please reload the page"))))
+
+        page.move_page(tb_target, tb_position)
         if is_installed('reversion'):
             self.cleanup_history(page)
-            helpers.make_revision_with_plugins(page, request.user, _("Page moved"))
+            helpers.make_revision_with_plugins(
+                page, request.user, _("Page moved"))
 
-        return jsonify_request(HttpResponse(admin_utils.render_admin_menu_item(request, page)))
+        return jsonify_request(
+            HttpResponse(admin_utils.render_admin_menu_item(request, page)))
 
     def get_permissions(self, request, page_id):
         page = get_object_or_404(self.model, id=page_id)
@@ -928,37 +990,75 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
     @transaction.atomic
     def copy_page(self, request, page_id, extra_context=None):
         """
-        Copy the page and all its plugins and descendants to the requested target, at the given position
-        """
-        context = {}
-        page = Page.objects.get(pk=page_id)
+        Copy the page and all its plugins and descendants to the requested
+        target, at the given position
 
+        NOTE: We have to change from one "coordinate system" to another to
+        adapt JSTree to Django Treebeard. See comments in move_page().
+
+        NOTE: This code handles more cases then are *currently* supported in
+        the UI, specifically, the target should never be None and the position
+        should never be non-zero. These are implemented, however, because we
+        intend to support these cases later.
+        """
         target = request.POST.get('target', None)
         position = request.POST.get('position', None)
-        site = request.POST.get('site', None)
-        if target is not None and position is not None and site is not None:
+        site_id = request.POST.get('site', None)
+        copy_permissions = request.POST.get('copy_permissions', False)
+
+        try:
+            page = self.model.objects.get(pk=page_id)
+        except self.model.DoesNotExist:
+            return jsonify_request(HttpResponseBadRequest("Error"))
+
+        try:
+            position = int(position)
+        except (TypeError, ValueError):
+            position = 0
+        try:
+            site = Site.objects.get(id=int(site_id))
+        except (TypeError, ValueError, MultipleObjectsReturned,
+                ObjectDoesNotExist):
+            site = get_current_site(request)
+
+        if target is None:
+            # Special case: If «target» is not provided, it means to create the
+            # new page as a root node.
             try:
-                target = self.model.objects.get(pk=target)
-                # does he have permissions to copy this page under target?
-                assert target.has_add_permission(request)
-                site = Site.objects.get(pk=site)
-            except (ObjectDoesNotExist, AssertionError):
-                return HttpResponse("error")
+                tb_target = Page.get_root_nodes().filter(
+                    publisher_is_draft=True, site=site)[position]
+                tb_position = "left"
+            except IndexError:
+                # New page to become the last root node.
+                tb_target = Page.get_last_root_node()
+                tb_position = "right"
+        else:
+            try:
+                tb_target = self.model.objects.get(pk=int(target), site=site)
+                assert tb_target.has_add_permission(request)
+            except (TypeError, ValueError, self.model.DoesNotExist,
+                    AssertionError):
+                return jsonify_request(HttpResponseBadRequest("Error"))
+            if position == 0:
+                # This is really the only possible value for position.
+                tb_position = "first-child"
             else:
+                # But, just in case...
                 try:
-                    permissions = request.GET.get('copy_permissions', False)
-                    if not permissions:
-                        permissions = request.POST.get('copy_permissions', False)
-                    kwargs = {
-                        'copy_permissions': permissions,
-                    }
-                    page.copy_page(target, site, position, **kwargs)
-                    return jsonify_request(HttpResponse("ok"))
-                except ValidationError:
-                    exc = sys.exc_info()[1]
-                    return jsonify_request(HttpResponseBadRequest(exc.messages))
-        context.update(extra_context or {})
-        return HttpResponseRedirect('../../')
+                    tb_target = target.get_children().filter(
+                        publisher_is_draft=True, site=site)[position]
+                    tb_position = "left"
+                except IndexError:
+                    tb_position = "last-child"
+        try:
+            new_page = page.copy_page(tb_target, site, tb_position,
+                                      copy_permissions=copy_permissions)
+            results = {"id": new_page.pk}
+            return HttpResponse(
+                json.dumps(results), content_type='application/json')
+        except ValidationError:
+            exc = sys.exc_info()[1]
+            return jsonify_request(HttpResponseBadRequest(exc.messages))
 
     @require_POST
     @transaction.atomic

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -186,7 +186,7 @@ class Page(six.with_metaclass(PageMetaClass, MP_Node)):
         """
         Called from admin interface when page is moved. Should be used on
         all the places which are changing page position. Used like an interface
-        to mptt, but after move is done page_moved signal is fired.
+        to django-treebeard, but after move is done page_moved signal is fired.
 
         Note for issue #1166: url conflicts are handled by updated
         check_title_slugs, overwrite_url on the moved page don't need any check

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -468,9 +468,7 @@ var CMS = window.CMS || {};
         _getNodeId: function _getElement(el) {
             return el.closest('.jstree-grid-cell')
                 .attr('class')
-                .split(' ')[0]
-                .replace('jsgrid_', '')
-                .replace('_col', '');
+                .replace(/.*jsgrid_(\d+)_col.*/, '$1');
         },
 
         /**
@@ -487,7 +485,8 @@ var CMS = window.CMS || {};
             var parent = this.ui.tree.jstree('get_parent', element);
             var nextDom = this.ui.tree.jstree('get_next_dom', element, true);
             var prevDom = this.ui.tree.jstree('get_prev_dom', element, true);
-            var parentDom = this.ui.tree.jstree('get_node', parent);
+            // this refers to the parent jstree node which is the tree itself
+            var parent = this.ui.tree.jstree('get_node', parent);
 
             // last-child if there is only one element (nested)
             // left if it can be placed before the get_next_dom (current sibling level)
@@ -498,9 +497,9 @@ var CMS = window.CMS || {};
             } else if (prevDom) {
                 obj.position = 'right';
                 obj.target = prevDom.data().id;
-            } else if (parentDom) {
+            } else if (parent) {
                 obj.position = 'last-child';
-                obj.target = parentDom.data.id;
+                obj.target = parent.data.id;
             } else {
                 obj.position = 'last-child';
             }
@@ -609,6 +608,8 @@ var CMS = window.CMS || {};
          * @private
          */
         _toggleHelpers: function _toggleHelpers() {
+            // helpers are generated on the fly, so we need to reference
+            // them every single time
             $('.cms-tree-item-helpers').toggleClass('cms-hidden');
         },
 

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -482,7 +482,7 @@ var CMS = window.CMS || {};
         },
 
         /**
-         * Gets the new position after moving.
+         * Gets the new node position after moving.
          *
          * @method _getNodePosition
          * @private

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -117,7 +117,7 @@ var CMS = window.CMS || {};
 
             // states and events
             this.click = 'click.cms.pagetree';
-            this.cache = null;
+            this.cacheTarget = null;
             this.cacheType = '';
             this.successTimer = 600;
 
@@ -276,7 +276,7 @@ var CMS = window.CMS || {};
             // store moved position node
             this.ui.tree.on('move_node.jstree copy_node.jstree', function (e, obj) {
                 if (!that.cacheType || that.cacheType === 'cut') {
-                    that._moveNode(that._getPosition(obj));
+                    that._moveNode(that._getNodePosition(obj));
                 } else {
                     that._copyNode(obj);
                 }
@@ -287,7 +287,7 @@ var CMS = window.CMS || {};
                 e.preventDefault();
                 // we need to cache the node and type so `_showHelpers`
                 // will trigger the correct behaviour
-                that.cache = e;
+                that.cacheTarget = $(e.currentTarget);
                 that.cacheType = $(this).hasClass('js-cms-tree-item-cut') ? 'cut' : 'copy';
                 that._showHelpers();
             });
@@ -299,10 +299,10 @@ var CMS = window.CMS || {};
                 // hide helpers after we picked one
                 that._hideHelpers();
 
-                var copyFromId = that._getNodeId($(that.cache.currentTarget));
+                var copyFromId = that._getNodeId(that.cacheTarget);
                 var copyToId = that._getNodeId($(e.currentTarget));
 
-                console.log('copy from: ', copyFromId, $(that.cache.currentTarget).data().id);
+                console.log('copy from: ', copyFromId, that.cacheTarget.data().id);
                 console.log('copy to: ', copyToId, $(e.currentTarget).data().id);
 
                 // TODO it is currently not possible to copy/cut a node to the root
@@ -417,7 +417,7 @@ var CMS = window.CMS || {};
          */
         _copyNode: function _copyNode(obj) {
             var that = this;
-            var node = that._getPosition(obj);
+            var node = that._getNodePosition(obj);
             var data = {
                 site: this.options.site,
                 // we need to refer to the original item here, as the copied
@@ -484,12 +484,12 @@ var CMS = window.CMS || {};
         /**
          * Gets the new position after moving.
          *
-         * @method _getPosition
+         * @method _getNodePosition
          * @private
          * @param {Object} obj jstree move object
          * @return {Object} evaluated object with params
          */
-        _getPosition: function _getPosition(obj) {
+        _getNodePosition: function _getNodePosition(obj) {
             var data = {};
             var node = this.ui.tree.jstree('get_node', obj.node.parent);
 

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -180,7 +180,11 @@ var CMS = window.CMS || {};
                         value: function (node) {
                             // it needs to have the "colde" format and not "col-de"
                             // as jstree will convert "col-de" to "colDe"
-                            return node.data['col' + obj.key];
+                            if (node.data) {
+                                return node.data['col' + obj.key];
+                            } else {
+                                return '';
+                            }
                         },
                         width: obj.width || '1%'
                     });
@@ -202,7 +206,7 @@ var CMS = window.CMS || {};
                         // we need to store the opened items inside the localstorage
                         // as we have to load the pagetree with the previous opened
                         // state
-                        obj.openNodes = that._getNodes();
+                        obj.openNodes = that._getSotredNodeIds();
 
                         // we need to set the site id to get the correct tree
                         obj.site = that.options.site;
@@ -269,41 +273,46 @@ var CMS = window.CMS || {};
                 that._storeNodeId(el.node.data.id);
             });
 
-            // drag and dropping items and saving their states
-            $(document).on('dnd_stop.vakata', function (e, el) {
-                var node = that._getNodeData(el.data.obj.selector);
-                that._moveNode(node);
+            // store moved position node
+            this.ui.tree.on('move_node.jstree copy_node.jstree', function (e, obj) {
+                if (!that.cacheType || that.cacheType === 'cut') {
+                    that._moveNode(that._getPosition(obj));
+                } else {
+                    that._copyNode(obj);
+                }
             });
 
             // set event for cut and paste
             this.ui.container.on(this.click, '.js-cms-tree-item-cut, .js-cms-tree-item-copy', function (e) {
                 e.preventDefault();
-                // we need to cache the node and type so `_toggleHelpers`
+                // we need to cache the node and type so `_showHelpers`
                 // will trigger the correct behaviour
-                that.cache = that._getNodeData(that._getNodeId($(this)));
+                that.cache = e;
                 that.cacheType = $(this).hasClass('js-cms-tree-item-cut') ? 'cut' : 'copy';
-                that._toggleHelpers();
+                that._showHelpers();
             });
 
             // attach events to paste
             this.ui.container.on(this.click, '.cms-tree-item-helpers a', function (e) {
                 e.preventDefault();
-                var target = that._getNodeData(that._getNodeId($(this)));
-                var obj = {
-                    target: target.id,
-                    position: 'first-child',
-                    id: that.cache.id
-                };
 
-                that._toggleHelpers();
+                // hide helpers after we picked one
+                that._hideHelpers();
 
-                // here we determine the cached type from the cut or copy events
+                var copyFromId = that._getNodeId($(that.cache.currentTarget));
+                var copyToId = that._getNodeId($(e.currentTarget));
+
+                console.log('copy from: ', copyFromId, $(that.cache.currentTarget).data().id);
+                console.log('copy to: ', copyToId, $(e.currentTarget).data().id);
+
+                // TODO it is currently not possible to copy/cut a node to the root
                 if (that.cacheType === 'cut') {
-                    that._moveNode(obj);
+                    that.ui.tree.jstree('cut', copyFromId);
+                } else {
+                    that.ui.tree.jstree('copy', copyFromId);
                 }
-                if (that.cacheType === 'copy') {
-                    that._copyNode(obj);
-                }
+
+                that.ui.tree.jstree('paste', copyToId, 'last');
             });
 
             // additional event handlers
@@ -318,11 +327,11 @@ var CMS = window.CMS || {};
         /**
          * Retreives a list of nodes from local storage.
          *
-         * @method _getNodes
+         * @method _getSotredNodeIds
          * @private
          * @return {Array} list of ids
          */
-        _getNodes: function _getNodes() {
+        _getSotredNodeIds: function _getSotredNodeIds() {
             return CMS.settings.pagetree || [];
         },
 
@@ -336,7 +345,7 @@ var CMS = window.CMS || {};
          */
         _storeNodeId: function _storeNodeId(id) {
             var number = id;
-            var storage = this._getNodes();
+            var storage = this._getSotredNodeIds();
 
             // store value only if it isn't there yet
             if (storage.indexOf(number) === -1) {
@@ -359,7 +368,7 @@ var CMS = window.CMS || {};
          */
         _removeNodeId: function _removeNodeId(id) {
             var number = id;
-            var storage = this._getNodes();
+            var storage = this._getSotredNodeIds();
             var index = storage.indexOf(number);
 
             // remove given id from storage
@@ -392,15 +401,6 @@ var CMS = window.CMS || {};
                 url: that.options.urls.move.replace('{id}', obj.id),
                 data: obj
             }).done(function () {
-                // we only need to move the node when not using drag & drop
-                // for example when we use copy & paste
-                // jstrees drag & drop will move the node for us
-                if (that.cache) {
-                    that.ui.tree.jstree('move_node',
-                        that.ui.tree.find('li[data-id="' + obj.id + '"]'),
-                        that.ui.tree.find('li[data-id="' + obj.target + '"]'));
-                    that.cache = null;
-                }
                 that._showSuccess(obj.id);
             }).fail(function (error) {
                 that.showError(error.statusText);
@@ -411,24 +411,32 @@ var CMS = window.CMS || {};
          * Copies a node into the selected node.
          *
          * @method _copyNode
-         * @param {Object} [opts]
-         * @param {Number} [opts.id] current element id for url matching
-         * @param {Number} [opts.target] target sibling or parent
-         * @param {Number} [opts.position] either `left`, `right` or `last-child`
+         * @param {String} copyFromId element to be cut
+         * @param {String} copyToId destination to inject
          * @private
          */
         _copyNode: function _copyNode(obj) {
             var that = this;
-            obj.site = that.options.site;
+            var node = that._getPosition(obj);
+            var data = {
+                site: this.options.site,
+                // we need to refer to the original item here, as the copied
+                // node will have no data attributes stored at it (not a clone)
+                id: obj.original.data.id,
+                position: node.position,
+                target: node.target
+            };
 
+            // we need to load a dialog first, to check if permissions should
+            // be copied or not
             $.ajax({
                 method: 'post',
-                url: that.options.urls.copyPermission.replace('{id}', obj.id),
-                data: obj
+                url: that.options.urls.copyPermission.replace('{id}', data.id),
+                data: data
             // the dialog is loaded via the ajax respons originating from
             // `templates/admin/cms/page/tree/copy_premissions.html`
-            }).done(function (data) {
-                that.ui.dialog.append(data);
+            }).done(function (dialog) {
+                that.ui.dialog.append(dialog);
             }).fail(function (error) {
                 that.showError(error.statusText);
             });
@@ -436,19 +444,21 @@ var CMS = window.CMS || {};
             // attach events to the permission dialog
             this.ui.dialog.off(this.click, '.cancel').on(this.click, '.cancel', function (e) {
                 e.preventDefault();
+                // remove just copied node
+                that.ui.tree.jstree('delete_node', obj.node.id);
                 $('.js-cms-dialog').remove();
             }).off(this.click, '.submit').on(this.click, '.submit', function (e) {
                 e.preventDefault();
-                var data = $(this).closest('form').serialize().split('&');
+                var formData = $(this).closest('form').serialize().split('&');
                 // loop through form data and attach to obj
-                for (var i = 0; i < data.length; i++) {
-                    obj[data[i].split('=')[0]] = data[i].split('=')[1];
+                for (var i = 0; i < formData.length; i++) {
+                    data[formData[i].split('=')[0]] = formData[i].split('=')[1];
                 }
                 // send the real ajax request for copying the plugin
                 $.ajax({
                     method: 'post',
-                    url: that.options.urls.copy.replace('{id}', obj.id),
-                    data: obj
+                    url: that.options.urls.copy.replace('{id}', data.id),
+                    data: data
                 }).done(function () {
                     CMS.API.Helpers.reloadBrowser();
                 }).fail(function (error) {
@@ -468,46 +478,38 @@ var CMS = window.CMS || {};
         _getNodeId: function _getElement(el) {
             return el.closest('.jstree-grid-cell')
                 .attr('class')
-                .replace(/.*jsgrid_(\d+)_col.*/, '$1');
+                .replace(/.*jsgrid_(.+?)_col.*/, '$1');
         },
 
         /**
-         * Sets up all the event handlers, such as opening and moving.
+         * Gets the new position after moving.
          *
-         * @method _getNodeData
+         * @method _getPosition
          * @private
-         * @param {String} id to look for in `get_node`
+         * @param {Object} obj jstree move object
          * @return {Object} evaluated object with params
          */
-        _getNodeData: function _getNodeData(id) {
-            var obj = {};
-            var element = this.ui.tree.jstree('get_node', id);
-            var parent = this.ui.tree.jstree('get_parent', element);
-            var nextDom = this.ui.tree.jstree('get_next_dom', element, true);
-            var prevDom = this.ui.tree.jstree('get_prev_dom', element, true);
-            // this refers to the jstree object which is the root tree itself
-            var root = this.ui.tree.jstree('get_node', parent);
+        _getPosition: function _getPosition(obj) {
+            var data = {};
+            var node = this.ui.tree.jstree('get_node', obj.node.parent);
 
-            // last-child if there is only one element (nested)
-            // left if it can be placed before the get_next_dom (current sibling level)
-            // right if it can be placed after the get_prev_dom (current sibling level)
-            if (nextDom) {
-                obj.position = 'left';
-                obj.target = nextDom.data().id;
-            } else if (prevDom) {
-                obj.position = 'right';
-                obj.target = prevDom.data().id;
-            } else if (root) {
-                obj.position = 'last-child';
-                obj.target = root.data.id;
+            data.position = obj.position;
+
+            // jstree indicates no parent with `#`, in this case we need the
+            // root id of the jstree
+            if (obj.parent === '#') {
+                data.target = -1;
             } else {
-                obj.position = 'last-child';
+                data.target = node.data.id;
             }
 
-            // set the id
-            obj.id = element.data.id;
+            if (obj.node && obj.node.data) {
+                data.id = obj.node.data.id;
+            }
 
-            return obj;
+            console.log('data: ', data);
+
+            return data;
         },
 
         /**
@@ -602,15 +604,27 @@ var CMS = window.CMS || {};
         },
 
         /**
-         * Shows and hides paste helpers.
+         * Shows paste helpers.
          *
-         * @method _toggleHelpers
+         * @method _showHelpers
          * @private
          */
-        _toggleHelpers: function _toggleHelpers() {
+        _showHelpers: function _showHelpers() {
             // helpers are generated on the fly, so we need to reference
             // them every single time
-            $('.cms-tree-item-helpers').toggleClass('cms-hidden');
+            $('.cms-tree-item-helpers').removeClass('cms-hidden');
+        },
+
+        /**
+         * Hides paste helpers.
+         *
+         * @method _hideHelpers
+         * @private
+         */
+        _hideHelpers: function _hideHelpers() {
+            // helpers are generated on the fly, so we need to reference
+            // them every single time
+            $('.cms-tree-item-helpers').addClass('cms-hidden');
         },
 
         /**

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -495,14 +495,14 @@ var CMS = window.CMS || {};
 
             data.position = obj.position;
 
-            // jstree indicates no parent with `#`, in this case we need the
-            // root id of the jstree
-            if (obj.parent === '#') {
-                data.target = -1;
-            } else {
+            // jstree indicates no parent with `#`, in this case we do not
+            // need to set the target attribute at all
+            if (obj.parent !== '#') {
                 data.target = node.data.id;
             }
 
+            // some functions like copy create a new element with a new id,
+            // in this case we need to set `data.id` manually
             if (obj.node && obj.node.data) {
                 data.id = obj.node.data.id;
             }

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -279,7 +279,7 @@ var CMS = window.CMS || {};
             this.ui.container.on(this.click, '.js-cms-tree-item-cut, .js-cms-tree-item-copy', function (e) {
                 e.preventDefault();
                 // we need to cache the node and type so `_toggleHelpers`
-                // wil trigger the correct behaviour
+                // will trigger the correct behaviour
                 that.cache = that._getNodeData(that._getNodeId($(this)));
                 that.cacheType = $(this).hasClass('js-cms-tree-item-cut') ? 'cut' : 'copy';
                 that._toggleHelpers();
@@ -485,8 +485,8 @@ var CMS = window.CMS || {};
             var parent = this.ui.tree.jstree('get_parent', element);
             var nextDom = this.ui.tree.jstree('get_next_dom', element, true);
             var prevDom = this.ui.tree.jstree('get_prev_dom', element, true);
-            // this refers to the parent jstree node which is the tree itself
-            var parent = this.ui.tree.jstree('get_node', parent);
+            // this refers to the jstree object which is the root tree itself
+            var root = this.ui.tree.jstree('get_node', parent);
 
             // last-child if there is only one element (nested)
             // left if it can be placed before the get_next_dom (current sibling level)
@@ -497,9 +497,9 @@ var CMS = window.CMS || {};
             } else if (prevDom) {
                 obj.position = 'right';
                 obj.target = prevDom.data().id;
-            } else if (parent) {
+            } else if (root) {
                 obj.position = 'last-child';
-                obj.target = parent.data.id;
+                obj.target = root.data.id;
             } else {
                 obj.position = 'last-child';
             }

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -399,8 +399,8 @@ var CMS = window.CMS || {};
                     that.ui.tree.jstree('move_node',
                         that.ui.tree.find('li[data-id="' + obj.id + '"]'),
                         that.ui.tree.find('li[data-id="' + obj.target + '"]'));
+                    that.cache = null;
                 }
-                that.cache = null;
                 that._showSuccess(obj.id);
             }).fail(function (error) {
                 that.showError(error.statusText);

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -302,9 +302,6 @@ var CMS = window.CMS || {};
                 var copyFromId = that._getNodeId(that.cacheTarget);
                 var copyToId = that._getNodeId($(e.currentTarget));
 
-                console.log('copy from: ', copyFromId, that.cacheTarget.data().id);
-                console.log('copy to: ', copyToId, $(e.currentTarget).data().id);
-
                 // TODO it is currently not possible to copy/cut a node to the root
                 if (that.cacheType === 'cut') {
                     that.ui.tree.jstree('cut', copyFromId);
@@ -506,8 +503,6 @@ var CMS = window.CMS || {};
             if (obj.node && obj.node.data) {
                 data.id = obj.node.data.id;
             }
-
-            console.log('data: ', data);
 
             return data;
         },

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -206,7 +206,7 @@ var CMS = window.CMS || {};
                         // we need to store the opened items inside the localstorage
                         // as we have to load the pagetree with the previous opened
                         // state
-                        obj.openNodes = that._getSotredNodeIds();
+                        obj.openNodes = that._getStoredNodeIds();
 
                         // we need to set the site id to get the correct tree
                         obj.site = that.options.site;
@@ -327,11 +327,11 @@ var CMS = window.CMS || {};
         /**
          * Retreives a list of nodes from local storage.
          *
-         * @method _getSotredNodeIds
+         * @method _getStoredNodeIds
          * @private
          * @return {Array} list of ids
          */
-        _getSotredNodeIds: function _getSotredNodeIds() {
+        _getStoredNodeIds: function _getStoredNodeIds() {
             return CMS.settings.pagetree || [];
         },
 
@@ -345,7 +345,7 @@ var CMS = window.CMS || {};
          */
         _storeNodeId: function _storeNodeId(id) {
             var number = id;
-            var storage = this._getSotredNodeIds();
+            var storage = this._getStoredNodeIds();
 
             // store value only if it isn't there yet
             if (storage.indexOf(number) === -1) {
@@ -368,7 +368,7 @@ var CMS = window.CMS || {};
          */
         _removeNodeId: function _removeNodeId(id) {
             var number = id;
-            var storage = this._getSotredNodeIds();
+            var storage = this._getStoredNodeIds();
             var index = storage.indexOf(number);
 
             // remove given id from storage

--- a/cms/templates/admin/cms/page/tree/menu.html
+++ b/cms/templates/admin/cms/page/tree/menu.html
@@ -9,6 +9,7 @@
     {% if not CMS_PERMISSION or has_add_permission %} cms-tree-node-root-allow-children{% endif %}
     "
     data-id="{{ page.pk }}"
+    data-slug="{{ page.get_slug }}"
     data-colview='
         <div class="cms-tree-col">
             <div class="cms-tree-item cms-tree-item-helpers cms-hidden">
@@ -132,7 +133,7 @@
                     <h3>{% trans "Information:" %}</h3>
                     <div class="cms-tree-tooltip-wrapper">
                         {% if page.publication_date %}
-                        <p><strong>{% trans "publication date" %}:</strong> {{ page.publication_date|date:"Y-m-d" }}</p>
+                            <p><strong>{% trans "publication date" %}:</strong> {{ page.publication_date|date:"Y-m-d" }}</p>
                         {% endif %}
                         {% if page.publication_end_date %}
                             <p><strong>{% trans "publication end date" %}:</strong> {{ page.publication_end_date|date:"Y-m-d" }}</p>

--- a/cms/templates/admin/cms/page/tree/menu_fragment.html
+++ b/cms/templates/admin/cms/page/tree/menu_fragment.html
@@ -1,7 +1,7 @@
 {% if messages and not page.children.count %}
-<ul class="messagelist">
-    {% for message in messages %}
-    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-    {% endfor %}
-</ul>
+    <ul class="messagelist">
+        {% for message in messages %}
+            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+        {% endfor %}
+    </ul>
 {% endif %}


### PR DESCRIPTION
Move, copy and cut worked unreliable. To change their behaviour we needed to switch from `dnd_stop.vakata` to the default jstree behaviours via `move_node.jstree copy_node.jstree`.

This required some restructuring and adaptions to the API. as the elements are stored in a more logical fashion.

There are additional cleanups included while refactoring that code.