### PR TITLE
Templates and page types

### DIFF
--- a/cms/test_utils/project/templates/integration/page.html
+++ b/cms/test_utils/project/templates/integration/page.html
@@ -4,6 +4,7 @@
 {% block title %}{% page_attribute 'title' %}{% endblock title %}
 
 {% block content %}
+    <h1>This is a custom page template</h1>
     {% placeholder "placeholder_content_1" %}
 {% endblock content %}
 

--- a/cms/tests/frontend/integration/addFirstPage.js
+++ b/cms/tests/frontend/integration/addFirstPage.js
@@ -20,7 +20,7 @@ casper.test.tearDown(function (done) {
         .run(done);
 });
 
-casper.test.begin('Add First Page', function (test) {
+casper.test.begin('Add First Page with wizard', function (test) {
     casper
         .start(globals.editUrl)
         .waitUntilVisible('.cms-modal', function () {

--- a/cms/tests/frontend/integration/createContent.js
+++ b/cms/tests/frontend/integration/createContent.js
@@ -40,10 +40,15 @@ casper.test.begin('User Add Content', function (test) {
             this.click('.cms-plugin-picker .cms-submenu-item [data-rel="add"]');
         })
         .waitWhileVisible('.cms-modal-morphing')
-        .waitUntilVisible('.cms-modal-open', function () {
+        .withFrame(0, function () {
+            // wait until modal fully loads
+            this.waitUntilVisible('#content');
+        })
+        .then(function () {
             this.setFilter('page.confirm', function () {
                 return true;
             });
+            // click on the "Cancel" button
             this.click('.cms-modal-item-buttons:last-child a');
         })
         .waitWhileVisible('.cms-modal-open', function () {

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -81,7 +81,8 @@ module.exports = function (casperjs) {
                     .then(function () {
                         this.sendKeys('#id_title', opts.title);
                         this.click('input[name="_save"]');
-                    });
+                    })
+                    .waitUntilVisible('.success');
             };
         },
 

--- a/cms/tests/frontend/integration/helpers/cms.js
+++ b/cms/tests/frontend/integration/helpers/cms.js
@@ -91,6 +91,7 @@ module.exports = function (casperjs) {
          * @param {Object} opts
          * @param {String} opts.type type of the plugin to add
          * @param {Object} opts.content object containing fields and values
+         * @param {Object} [opts.parent] selector of the parent cms-draggable
          * @example
          *
          *     cms.addPlugin({
@@ -108,8 +109,40 @@ module.exports = function (casperjs) {
                     .waitUntilVisible('.cms-toolbar-expanded', function () {
                         this.click('.cms-toolbar-item-cms-mode-switcher .cms-btn[href="?build"]');
                     })
+                    // only add to placeholder if no parent specified
+                    .thenBypassIf(opts.parent, 1)
                     .waitUntilVisible('.cms-structure', function () {
                         this.click('.cms-structure .cms-submenu-add [data-tooltip="Add plugin"]');
+                    })
+                    // if parent specified - try to add to it
+                    .thenBypassUnless(opts.parent, 1)
+                    .then(function () {
+                        // if the parent is expanded - click on "Add plugin"
+                        if (this.visible(opts.parent)) {
+                            this.click(opts.parent + ' [data-tooltip="Add plugin"]');
+                        } else {
+                            // get full selector (css3, not jquery) of the closest placeholder
+                            var parentSelector = this.evaluate(function (selector) {
+                                return $(selector).closest('.cms-dragarea').parentsUntil('body')
+                                    .andSelf()
+                                    .map(function () {
+                                        return this.nodeName + ':nth-child(' + ($(this).index() + 1) + ')';
+                                    }).get().join('>');
+                            }, opts.parent);
+
+                            // check if "Expand all" is visible
+                            if (this.visible(parentSelector + ' .cms-dragbar-expand-all')) {
+                                this.click(parentSelector + ' .cms-dragbar-expand-all');
+                            } else {
+                                // if not visible, then first "Collapse all"
+                                this.click(parentSelector + ' .cms-dragbar-collapse-all');
+                                this.wait(100);
+                                this.click(parentSelector + ' .cms-dragbar-expand-all');
+                            }
+
+                            this.wait(100);
+                            this.click(opts.parent + ' [data-tooltip="Add plugin"]');
+                        }
                     })
                     .waitUntilVisible('.cms-plugin-picker .cms-submenu-item [data-rel="add"]', function () {
                         this.then(function () {

--- a/cms/tests/frontend/integration/logout.js
+++ b/cms/tests/frontend/integration/logout.js
@@ -13,7 +13,12 @@ casper.test.setUp(function (done) {
         .run(done);
 });
 
-casper.test.tearDown(function () {
+casper.test.tearDown(function (done) {
+    casper.start()
+        .then(cms.login())
+        .then(cms.removePage())
+        .then(cms.logout())
+        .run(done);
 });
 
 casper.test.begin('User Logout', function (test) {
@@ -25,6 +30,7 @@ casper.test.begin('User Logout', function (test) {
         .waitForSelector('.cms-toolbar-item-navigation-hover', function () {
             this.click('.cms-toolbar-item-navigation-hover a[href$="/admin/logout/"]');
         })
+        .waitForResource(/logout/)
         .waitForSelector('.nav', function () {
             test.assertDoesntExist('.cms-toolbar', 'Logout via the toolbar done');
         })

--- a/cms/tests/frontend/integration/pageTypes.js
+++ b/cms/tests/frontend/integration/pageTypes.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// #############################################################################
+// Page types and templates
+
+var globals = require('./settings/globals');
+var randomString = require('./helpers/randomString').randomString;
+var casperjs = require('casper');
+var cms = require('./helpers/cms')(casperjs);
+var xPath = casperjs.selectXPath;
+
+var SECOND_PAGE_TITLE = 'Second';
+
+casper.test.setUp(function (done) {
+    casper.start()
+        .then(cms.login())
+        // .then(cms.addPage({ title: 'First page' }))
+        // adding second one because first is published by default
+        // .then(cms.addPage({ title: SECOND_PAGE_TITLE }))
+        .run(done);
+});
+
+casper.test.tearDown(function (done) {
+    casper.start()
+        // .then(cms.removePage({ title: SECOND_PAGE_TITLE }))
+        // .then(cms.removePage({ title: 'First page' })) // removing both pages
+        .then(cms.logout())
+        .run(done);
+});
+
+0 && casper.test.begin('Different page template can be applied', function (test) {
+    casper.start(globals.editUrl)
+        .waitUntilVisible('.cms-toolbar-expanded', function () {
+            test.assertDoesntExist('h1', 'Page is "fullwidth.html"');
+            // click on "Page" menu item
+            this.click('.cms-toolbar-item-navigation > li:nth-child(2) > a');
+        })
+        // expand "Templates" menu item
+        .waitForSelector('.cms-toolbar-item-navigation-hover', function () {
+            var position = this.getElementBounds(xPath('//a[.//span[text()[contains(.,"Templates")]]]'));
+            // simulating mouseenter event
+            this.mouse.move(position.left + 1, position.top - 1);
+            this.mouse.move(position.left + 1, position.top + 1);
+            this.wait(10);
+        })
+        // wait till it expands
+        .waitForSelector('.cms-toolbar-item-navigation-hover .cms-toolbar-item-navigation-hover', function () {
+            // move right
+            this.mouse.move(
+                xPath('//a[.//span[text()[contains(.,"Fullwidth")]]]')
+            );
+            // move down
+            this.mouse.move(
+                xPath('//a[.//span[text()[contains(.,"Standard page")]]]')
+            );
+            this.click(
+                xPath('//a[.//span[text()[contains(.,"Standard page")]]]')
+            );
+        })
+        .waitForResource(/change_template/)
+        .waitForSelector('.cms-ready', function () {
+            test.assertSelectorHasText(
+                '.cms-toolbar-item-navigation-active',
+                'Standard page',
+                'Correct template is highlighted in the menu'
+            );
+            test.assertExists('h1', 'Page is "page.html"');
+            test.assertSelectorHasText('h1', 'This is a custom page template', 'Page is "page.html"');
+        })
+        .run(function () {
+            test.done();
+        });
+});
+
+casper.test.begin('PageType can be created and used', function (test) {
+    casper.start(globals.editUrl)
+        // actually creates 3 plugins - row > col + col
+        .then(cms.addPlugin({
+            type: 'GridPlugin',
+            content: {
+                id_create: 2,
+                id_create_size: 12
+            }
+        }))
+        .then(cms.addPlugin({
+            type: 'TextPlugin',
+            content: {
+                id_body: 'Left column'
+            },
+            parent: '.cms-dragarea:first-child .cms-draggable .cms-draggable:first-child'
+        }))
+        .then(cms.addPlugin({
+            type: 'TextPlugin',
+            content: {
+                id_body: 'Right column'
+            },
+            parent: '.cms-dragarea:first-child .cms-draggable .cms-draggable:last-child'
+        }))
+        .run(function () {
+            test.done();
+        });
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,6 +188,7 @@ gulp.task('tests:integration', function (done) {
         'newPage',
         'pageControl',
         'permissions',
+        'pageTypes',
         'switchLanguage',
         'editContent',
         'editContentTools',


### PR DESCRIPTION
- [x] Go to Page > Templates and switch template
- [x] Test that the new template is applied
- [x] Create a pagetype by using Page > Save as Page Type
- [x] Create a page by using a pagetype

additionally page type test tests page creation flow from toolbar menu
also added a "parent" option to `cms.addPlugin` to create more complex structures 
also fixes teardown in logout test (which might have affected the overall build)
also fixes the wait for the modal load when plugin creation is canceled